### PR TITLE
Add MyVibe Skills to Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,3 +607,4 @@ Reusable skill packages, collections, and tools for enhancing AI coding agents w
 - [UI UX Pro Max](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) - An AI skill that provides design intelligence for building professional UI/UX across multiple platforms and frameworks.
 - [Karpathy-Inspired Claude Code Guidelines](https://github.com/forrestchang/andrej-karpathy-skills) - A single CLAUDE.md file to improve Claude Code behavior, derived from Andrej Karpathy's observations on LLM coding pitfalls.
 - [Frontend-King-Mode](https://github.com/sendralt/Frontend-King-Mode) - A "God Mode" system instruction, skill, mode, rule, or simply the first prompt to begin a vibecoded app.
+- [MyVibe Skills](https://github.com/ArcBlock/myvibe-skills) - Instantly publish AI-generated web apps to MyVibe.so. Auto-detects Static, Vite, Next.js, Astro, and Nuxt projects with smart build integration.


### PR DESCRIPTION
## Summary
- Added [MyVibe Skills](https://github.com/ArcBlock/myvibe-skills) to the Skills section

## About MyVibe Skills
MyVibe Skills enables AI coding agents to instantly publish web apps to [MyVibe.so](https://myvibe.so).

**Key features:**
- Auto-detects project types: Static, Vite, Next.js, Astro, Nuxt
- Smart build integration (npm, pnpm, yarn, bun)
- Automatic metadata extraction and screenshot generation
- Version tracking for existing vibes

**Installation:**
```bash
npx skills add ArcBlock/myvibe-skills
```

Works with Claude Code, Cursor, Codex, Gemini CLI, and [35+ more agents](https://github.com/vercel-labs/skills#supported-agents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)