### PR TITLE
Add Mysti - Multi-agent AI coding assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,3 +628,4 @@ Reusable skill packages, collections, and tools for enhancing AI coding agents w
 - [Heavy3 Code Audit (`/h3`)](https://github.com/heavy3-ai/code-audit) - Agent skill that uses multi-model consensus to review plans, code, and PRs for coding agents
 - [setup-structure-index](https://github.com/shannonbay/setup-structure-index) - A Claude Code skill that sets up a two-tier codebase structure index for any project.
 - [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 plug-and-play product management agent skills with templates and workflow bundles, following the agentskills.io specification.
+| [Mysti](https://github.com/DeepMyst/Mysti) | Multi-agent AI coding assistant for VS Code with brainstorm mode | Claude Code, Codex, Gemini, Cline, GitHub Copilot |


### PR DESCRIPTION
## What is Mysti?

[Mysti](https://github.com/DeepMyst/Mysti) is an open-source VS Code extension that provides a unified AI coding assistant interface supporting multiple backends:

- **Multi-provider**: Claude Code, OpenAI Codex, Google Gemini, Cline, GitHub Copilot
- **Brainstorm mode**: Select 2 AI agents to debate, red-team, or collaborate on solutions
- **Conversation persistence**: Save and resume coding sessions
- **MCP integration**: Model Context Protocol permission server
- **Plan selection**: Multiple implementation plan strategies

### Links
- GitHub: https://github.com/DeepMyst/Mysti
- Homepage: https://www.deepmyst.com/mysti