### PR TITLE
Add Poirot to Project & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Tools for project management, documentation, and knowledge organization in AI-dr
 - [Mantra](https://mantra.gonewx.com) - Time-travel debugger for AI coding sessions. Branch, snapshot, and restore your Claude Code, Cursor, Windsurf, and Copilot sessions as navigable timelines.
 - [Vibe Kanban](https://github.com/BloopAI/vibe-kanban) - Get 10X more out of Claude Code, Gemini CLI, Codex, Amp and other coding agents with an AI-powered kanban board.
 - [Planning with Files](https://github.com/OthmanAdi/planning-with-files) - A Claude Code skill that transforms your workflow to use persistent markdown files for planning, progress tracking, and knowledge storage — the exact pattern that made Manus worth billions.
+- [Poirot](https://github.com/LeonardoCardoso/Poirot) - A macOS app for browsing Claude Code sessions, exploring diffs, and re-running commands. Reads local transcripts, runs offline.
 - [AI-AfterImage](https://github.com/DragonShadows1978/AI-AfterImage) - Episodic memory for AI coding agents. The ghost of code written, persisting across sessions.
 - [Smart Ralph](https://github.com/tzachbon/smart-ralph) - Spec-driven development with smart compaction. Claude Code plugin combining Ralph Wiggum loop with structured specification workflow.
 - [GET SHIT DONE](https://github.com/glittercowboy/get-shit-done) - A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code by TÂCHES.

--- a/README_JA.md
+++ b/README_JA.md
@@ -372,6 +372,7 @@ AI駆動開発におけるプロジェクト管理、ドキュメント、ナレ
 - [Mantra](https://mantra.gonewx.com) - AIコーディングセッション向けタイムトラベルデバッガー。Claude Code、Cursor、Windsurf、Copilotのセッションをナビゲート可能なタイムラインとしてブランチ、スナップショット、復元
 - [Vibe Kanban](https://github.com/BloopAI/vibe-kanban) - AI搭載カンバンボードでClaude Code、Gemini CLI、Codex、Ampなどのコーディングエージェントから10倍の成果を引き出す
 - [Planning with Files](https://github.com/OthmanAdi/planning-with-files) - プランニング、進捗追跡、ナレッジストレージ用の永続的なmarkdownファイルを使用するようワークフローを変革するClaude Codeスキル — Manusを数十億ドル企業にした手法
+- [Poirot](https://github.com/LeonardoCardoso/Poirot) - Claude Codeのセッションを閲覧し、差分を調査し、コマンドを再実行するためのmacOSアプリ。
 - [AI-AfterImage](https://github.com/DragonShadows1978/AI-AfterImage) - AIコーディングエージェント向けのエピソディックメモリ。書かれたコードの残像がセッション間で持続
 - [Smart Ralph](https://github.com/tzachbon/smart-ralph) - スマートコンパクション付きスペック駆動開発。Ralph Wiggumループと構造化仕様ワークフローを組み合わせたClaude Codeプラグイン
 - [GET SHIT DONE](https://github.com/glittercowboy/get-shit-done) - TÂCHESによるClaude Code向けの軽量かつ強力なメタプロンプティング、コンテキストエンジニアリング、スペック駆動開発システム


### PR DESCRIPTION
Poirot is an open source macOS app for browsing Claude Code sessions. It reads local JSONL transcripts and shows conversations, tool blocks, diffs, and lets you re-run commands. MIT licensed.

Updated both README.md and README_JA.md as per contributing guidelines.

https://github.com/LeonardoCardoso/Poirot