### PR TITLE
Add ORCH to Terminal & CLI Agents and Multi-Agent & Orchestration sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Plugins and extensions for popular IDEs and text editors.
 - [Co-Clone](https://github.com/Sarvesh-Kannan/Co-Clone) - a local AI coding assistant that mimics the functionality of GitHub Copilot. It provides intelligent code completions and context-aware implementations using a local LLM (deepseek-coder:6.7b) running via Ollama.
 - [eca](https://github.com/editor-code-assistant/eca) - AI pair programming capabilities agnostic of editor
 
+- [ORCH](https://github.com/oxgeneral/ORCH) — CLI orchestrator for Claude Code, Codex, Cursor agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. TypeScript, MIT.
 ## Multi-Agent & Orchestration
 
 Frameworks and tools for orchestrating and managing multiple AI agents in development workflows.
@@ -208,6 +209,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Slate V1](https://randomlabs.ai/) - A generalist software agent built for swarms.
 - [Blackbox Code](https://github.com/blackboxaicode/cli) - BLACKBOX CLI for running Multi-Agents locally and a Judge to select the best task implementation
 
+- [ORCH](https://github.com/oxgeneral/ORCH) — CLI orchestrator for Claude Code, Codex, Cursor agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. TypeScript, MIT.
 ## Code Generation & Automation
 
 Tools for generating code, automating development tasks, and creating project templates.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Slate V1](https://randomlabs.ai/) - A generalist software agent built for swarms.
 - [Blackbox Code](https://github.com/blackboxaicode/cli) - BLACKBOX CLI for running Multi-Agents locally and a Judge to select the best task implementation
 
-- [ORCH](https://github.com/oxgeneral/ORCH) — CLI orchestrator for Claude Code, Codex, Cursor agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. TypeScript, MIT.
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator for Claude Code, Codex, Cursor agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. TypeScript, MIT.
 ## Code Generation & Automation
 
 Tools for generating code, automating development tasks, and creating project templates.

--- a/README_JA.md
+++ b/README_JA.md
@@ -159,6 +159,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Co-Clone](https://github.com/Sarvesh-Kannan/Co-Clone) - GitHub Copilotの機能を模倣するローカルAIコーディングアシスタント。Ollama経由でローカルLLM（deepseek-coder:6.7b）を使用してインテリジェントなコード補完とコンテキスト認識実装を提供
 - [eca](https://github.com/editor-code-assistant/eca) - エディタに依存しないAIペアプログラミング機能
 
+- [ORCH](https://github.com/oxgeneral/ORCH) — Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
 ## マルチエージェント & オーケストレーション
 
 開発ワークフローで複数のAIエージェントを調整・管理するフレームワークとツール。
@@ -207,6 +208,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Slate V1](https://randomlabs.ai/) - スウォーム向けに構築された汎用ソフトウェアエージェント
 - [Blackbox Code](https://github.com/blackboxaicode/cli) - マルチエージェントをローカルで実行し、最適なタスク実装を選択するジャッジ機能を備えたBLACKBOX CLI
 
+- [ORCH](https://github.com/oxgeneral/ORCH) — Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
 ## コード生成 & 自動化
 
 コード生成、開発タスクの自動化、プロジェクトテンプレート作成のためのツール。

--- a/README_JA.md
+++ b/README_JA.md
@@ -208,7 +208,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Slate V1](https://randomlabs.ai/) - スウォーム向けに構築された汎用ソフトウェアエージェント
 - [Blackbox Code](https://github.com/blackboxaicode/cli) - マルチエージェントをローカルで実行し、最適なタスク実装を選択するジャッジ機能を備えたBLACKBOX CLI
 
-- [ORCH](https://github.com/oxgeneral/ORCH) — Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
+- [ORCH](https://github.com/oxgeneral/ORCH) - Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
 ## コード生成 & 自動化
 
 コード生成、開発タスクの自動化、プロジェクトテンプレート作成のためのツール。

--- a/README_JA.md
+++ b/README_JA.md
@@ -159,7 +159,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Co-Clone](https://github.com/Sarvesh-Kannan/Co-Clone) - GitHub Copilotの機能を模倣するローカルAIコーディングアシスタント。Ollama経由でローカルLLM（deepseek-coder:6.7b）を使用してインテリジェントなコード補完とコンテキスト認識実装を提供
 - [eca](https://github.com/editor-code-assistant/eca) - エディタに依存しないAIペアプログラミング機能
 
-- [ORCH](https://github.com/oxgeneral/ORCH) — Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
+- [ORCH](https://github.com/oxgeneral/ORCH) - Claude Code、Codex、Cursor エージェントチームのためのCLIオーケストレーター。ステートマシン、自動リトライ、エージェント間メッセージング、TUIダッシュボード。TypeScript、MIT。
 ## マルチエージェント & オーケストレーション
 
 開発ワークフローで複数のAIエージェントを調整・管理するフレームワークとツール。


### PR DESCRIPTION
## 変更内容の要約

Terminal & CLI AgentsセクションとMulti-Agent & Orchestrationセクションに[ORCH](https://github.com/oxgeneral/ORCH)を追加しました。

## 変更内容

- ORCH (https://github.com/oxgeneral/ORCH) をTerminal & CLI Agentsセクションに追加
- ORCH (https://github.com/oxgeneral/ORCH) をMulti-Agent & Orchestrationセクションに追加
- README.mdとREADME_JA.mdを更新

## ツールの概要

ORCHについて
Claude Code、Codex、Cursor、OpenCode、shellスクリプトをチームとして協調させるCLIオーケストレーター。タスクのライフサイクル管理（state machine: todo → in_progress → review → done）、自動リトライ、エージェント間メッセージング（orch msg send/broadcast）、TUIダッシュボード（Ink/React）を備える。TypeScript製、MIT License、npm install一発で使用可能。