### PR TITLE
Update README with LAP code generation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 ## Code Generation & Automation
 
 Tools for generating code, automating development tasks, and creating project templates.
-
+- [LAP](https://github.com/Lap-Platform/LAP) - Compiles API specs into lean, token-efficient formats that prevent AI agent hallucinations. Supports OpenAPI, GraphQL, AsyncAPI, Protobuf & Postman. Ships with a registry of 1,500+ pre-compiled specs.
 - [gpt-engineer](https://github.com/gpt-engineer-org/gpt-engineer) - Specify what you want it to build, the AI asks for clarification, and then builds it
 - [amplication](https://github.com/amplication/amplication) - The Only Production-Ready AI-Powered Backend Code Generation
 - [llamacoder](https://github.com/Nutlope/llamacoder) - An open source Claude Artifacts – generate small apps with one prompt

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **520 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **522 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 


### PR DESCRIPTION
Added LAP to the list of code generation tools in the README.

LAP compiles API specs into lean formats that prevent AI agent hallucinations. 1,500+ pre-compiled specs in the registry.

- GitHub: https://github.com/Lap-Platform/LAP
- Registry: https://registry.lap.sh

<!---
# 書き方については以下のプルリクエストを参照

https://github.com/eltociear/awesome-AI-driven-development/pull/2

プルリクエストには要約、変更内容、ツールの概要を書くこと。

-->

## 変更内容の要約

XXXセクションに[XXX]を追加しました。

## 変更内容

書き方の例：

```text
- Strix (https://github.com/usestrix/strix) をTesting & Securityセクションに追加
- ツール総数を311個から312個に更新
```

## ツールの概要

書き方の例：

```text
Strixについて
「AIハッカー」として機能するオープンソースのセキュリティエージェント。開発ワークフローに統合し、アプリケーションの脆弱性を能動的にテスト・発見する。ローカルで実行し、継続的なセキュリティテストを自動化できる。
```
