### PR TITLE
Add Cortex Code to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **522 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **523 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -100,6 +100,7 @@ AI coding assistants and agents that work directly in your terminal or command l
 - [Codi](https://github.com/laynepenney/codi) - Your AI coding wingman - a hybrid assistant supporting Claude, OpenAI, and local models
 - [Termly CLI](https://github.com/termly-dev/termly-cli) - Access your AI coding assistants from any device. Works with Claude Code, Aider, GitHub Copilot, and any terminal-based AI tool.
 - [Codex DMG -> Windows](https://github.com/aidanqm/Codex-Windows) - This repository provides a Windows-only runner that extracts the macOS Codex DMG and runs the Electron app on Windows.
+- [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) - Snowflake's AI coding agent CLI for SQL, Python, and data engineering workflows with built-in Snowflake connectivity
 
 ## IDE Extensions
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **517個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **518個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -99,6 +99,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Codi](https://github.com/laynepenney/codi) - AIコーディングの相棒。Claude、OpenAI、ローカルモデルをサポートするハイブリッドアシスタント
 - [Termly CLI](https://github.com/termly-dev/termly-cli) - 任意のデバイスからAIコーディングアシスタントにアクセス。Claude Code、Aider、GitHub Copilot、その他のターミナルベースAIツールと連携
 - [Codex DMG -> Windows](https://github.com/aidanqm/Codex-Windows) - macOS版Codex DMGを抽出してWindows上でElectronアプリを実行するWindows専用ランナーを提供するリポジトリ
+- [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) - SnowflakeのAIコーディングエージェントCLI。SQL、Python、データエンジニアリングワークフローをSnowflake接続機能とともに提供
 
 ## IDE拡張機能
 


### PR DESCRIPTION
## Summary of changes
Added [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) to the Terminal & CLI Agents section.

## Changes
- Added Cortex Code entry to `README.md` (English)
- Added Cortex Code entry to `README_JA.md` (Japanese)
- Updated tool count from 522 to 523 (English) and 517 to 518 (Japanese)

## Tool overview
Cortex Code is Snowflake's AI coding agent CLI for SQL, Python, and data engineering workflows with built-in Snowflake connectivity. It runs in the terminal alongside tools like Claude Code, Codex CLI, and Gemini CLI.