### PR TITLE
Add Burnd to Code Analysis & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Tools for analyzing, searching, and understanding codebases.
 - [AI Agent Context Optimizer 🤖](https://github.com/guyaluk/contextor) - A GitHub Action that automatically analyzes your codebase and generates focused AI agent context documentation recommendations (CLAUDE.md, AGENTS.md, or similar) for AI coding assistants
 - [ccusage](https://github.com/ryoppippi/ccusage) - A CLI tool for analyzing Claude Code/Codex CLI usage from local JSONL files.
 - [BurnRate](https://getburnrate.io) - Local-first AI coding cost analytics. Tracks Claude Code, Cursor, Codex, Copilot, Windsurf, Cline, and Aider. Cost breakdowns, 23 optimization rules, rate limit monitoring, provider comparison, and PDF reports.
+- [Burnd](https://github.com/garvitsurana/burnd) - Local-first CLI that parses Claude Code JSONL session files and runs 8 cost-leak detectors (retry storms, tool overuse, repeated reads, thrash, tired-coding). Prints savings estimates plus shareable report URLs. MIT, npx-installable, zero telemetry.
 - [Sourcebot](https://github.com/sourcebot-dev/sourcebot) - a self-hosted tool that helps you understand your codebase.
 - [codemap 🗺️](https://github.com/JordanCoin/codemap) - a project brain for your AI. Give LLMs instant architectural context without burning tokens.
 - [GitNexus V2](https://github.com/abhigyanpatwari/GitNexus) - a client-side knowledge graph creator that runs entirely in your browser. Drop in a GitHub repo or ZIP file, and get an interactive knowledge graph wit a built in Graph RAG Agent. Perfect for code exploration


### PR DESCRIPTION
Adds Burnd next to ccusage / BurnRate / vibe-log-cli in Code Analysis & Search — the three entries that already analyze local Claude Code session data to produce insights.

Burnd extends that pattern with leak-detection: eight pattern detectors (retry storms, tool overuse, repeated reads, thrash, tired-coding, long bash output, project cost outliers, skill firings) run over ~/.claude/projects/*.jsonl and surface the specific sessions driving cost. Output includes a local summary plus a shareable report URL.

- Repo: https://github.com/garvitsurana/burnd
- npm: getburnd
- Site: https://getburnd.vercel.app
- MIT, local-first.