### PR TITLE
Add AI Context Templates, AI Context Linter, and url-to-md

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,9 @@ Tools for project management, documentation, and knowledge organization in AI-dr
 - [Nemp Memory](https://github.com/SukinShetty/Nemp-memory) - 100% Local Memory for Claude Code • Privacy-First • Zero Setup
 - [🏗️ Vibe Architect](https://github.com/mohdhd/vibe-architect) - AI-powered project spec generator — go from idea to implementation-ready spec in minutes. Multi-model support (GPT-5.2, Gemini 3, Claude), live design previews, voice input, and export to markdown.
 - [MemoryAgent](https://github.com/IIIIQIIII/MemoryAgent) - Letting Coding Agents manage their own memory without databases.
+- [AI Context Templates](https://github.com/MrDwarf7/ai-context-templates) - Free CLAUDE.md, Cursor rules, and PRP templates for common project types. 5 ready-to-use packs that make AI coding assistants actually useful.
+- [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.
+- [url-to-md](https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup.
 
 ## Language Models & Engines
 


### PR DESCRIPTION
Adding three open-source AI developer tools to the Project & Knowledge Management section:

1. **AI Context Templates** (https://github.com/MrDwarf7/ai-context-templates) - Free CLAUDE.md, Cursor rules, and PRP templates for common project types. 5 ready-to-use packs that help developers get better results from AI coding assistants.

2. **AI Context Linter** (https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.

3. **url-to-md** (https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup.

Disclosure: I am the creator of these tools. All are publicly available, open-source, and actively maintained.