### PR TITLE
feat: add KubeStellar Console kc-agent to MCP Servers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Model Context Protocol servers and integrations for enhanced AI capabilities.
 - [Browser Control MCP](https://github.com/eyalzh/browser-control-mcp) - MCP server paired with a browser extension that enables AI agents to control the user's browser.
 - [LINE Bot MCP Server](https://github.com/line/line-bot-mcp-server) - MCP server that integrates the LINE Messaging API to connect an AI Agent to the LINE Official Account.
 - [Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-server) - Model Context Protocol (MCP) server for Kubernetes and OpenShift
+- [KubeStellar Console kc-agent](https://github.com/kubestellar/console) - MCP server (kc-agent) bundled with KubeStellar Console for AI-driven multi-cluster Kubernetes operations — natural-language chat, GitOps deploy missions, and real-time cluster dashboard via Claude/Copilot/Cursor
 - [Computer Control MCP](https://github.com/AB498/computer-control-mcp) - MCP server that provides computer control capabilities, like mouse, keyboard, OCR, etc. using PyAutoGUI, RapidOCR, ONNXRuntime. Similar to 'computer-use' by Anthropic. With Zero External Dependencies.
 - [Ref MCP](https://github.com/ref-tools/ref-tools-mcp) - An MCP server to stop hallucinations with token efficient search over public and private documentation.
 - [DockaShell](https://github.com/anzax/dockashell) - DockaShell is an MCP server that gives AI agents isolated Docker containers to work in. MCP tools for shell access, file operations, and full audit trail.


### PR DESCRIPTION
## What

Adds **KubeStellar Console kc-agent** to the **MCP Servers & Integrations** section, right next to the existing Kubernetes MCP Server entry.

## Why

kc-agent is the MCP server bundled with [KubeStellar Console](https://github.com/kubestellar/console) — a purpose-built Kubernetes MCP server that goes beyond cluster API access to provide:

- 🤖 Natural-language cluster operations via Claude/Copilot/Cursor
- 🚀 GitOps deploy missions for automated multi-cluster workload placement  
- 📊 Real-time monitoring across federated clusters (edge, on-prem, cloud)
- 🔌 Full MCP toolset: list namespaces, get pods, apply manifests, check status

It complements the existing [Kubernetes MCP Server](https://github.com/containers/kubernetes-mcp-server) entry with a higher-level cluster-management focus.

**Links:** [GitHub](https://github.com/kubestellar/console) · [Live demo](https://console.kubestellar.io) · [Docs](https://docs.kubestellar.io)