### PR TITLE
Add prpack and prpack-action to Code Review & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ Tools for code review, pull request automation, and team collaboration.
 - [Costrict](https://github.com/zgsm-ai/costrict) - strict AI coder for enterprises, quality first, including AI Agent, AI CodeReview, AI Completion.
 - [ThinkReview](https://github.com/Thinkode/thinkreview-browser-extension) - a production-ready browser extension that brings AI-powered code reviews to GitLab and Azure DevOps.
 - [gh-dash - GitHub PR Dashboard for Claude Code](https://github.com/jakozloski/claude-code-gh-dash) - A Claude Code plugin that displays GitHub PR status, CI/CD checks, and merge capability directly in your terminal.
+- [prpack](https://github.com/Lucas2944/prpack) - CLI that packs a pull request (diff + commits + full post-change file contents) into one markdown file optimized for LLM code review. MIT.
+- [prpack-action](https://github.com/Lucas2944/prpack-action) - GitHub Action that runs prpack on every PR, uploads the packed markdown as an artifact, and posts a summary comment.
 
 ## Project & Knowledge Management
 


### PR DESCRIPTION
Adding two related entries to the **Code Review & Collaboration** section:

- [prpack](https://github.com/Lucas2944/prpack) — a zero-dependency Node CLI (MIT) that packs a pull request (commits, diff, and full post-change file contents) into one markdown file. Drop the file into Claude / Cursor / your model and ask for review. Released [v0.1.0](https://github.com/Lucas2944/prpack/releases/tag/v0.1.0).

- [prpack-action](https://github.com/Lucas2944/prpack-action) — a GitHub Action wrapper around prpack. On every PR it produces the packed markdown, uploads it as an artifact, and posts a summary comment. Released [v1.0.0](https://github.com/Lucas2944/prpack-action/releases/tag/v1.0.0).

Both fit the existing format of the section (`pr-agent`, `ai-pr-reviewer`, `gitpack-ai`, `kodus`, `gh-dash` for Claude Code).

The technique behind the tool is written up here: [Your LLM code reviewer is reading half the file](https://scottthurman.hashnode.dev/your-llm-code-reviewer-is-reading-half-the-file).