### PR TITLE
Add AWB (AI Workflow Benchmark) to Testing & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ AI-powered tools for testing, quality assurance, security analysis, and code cov
 - [Eval Marketplace](https://github.com/JeredBlu/eval-marketplace) - Comprehensive security evaluation tools for agent skills and MCP servers, powered by GitHub and Bright Data integrations.
 - [Vet : Verify Everything](https://github.com/imbue-ai/vet) - a standalone verification tool for code changes and coding agent behavior.
 - [Hawkeye](https://github.com/MLaminekane/hawkeye) - The flight recorder for AI agents - observability and security for Claude Code, Aider, AutoGPT and more
+- [AWB (AI Workflow Benchmark)](https://github.com/xmpuspus/ai-workflow-benchmark) - Open-source benchmark for AI coding workflows on 100 real OSS tasks at pinned commit SHAs. 9 adapters (Claude Code vanilla and custom, Cursor, Aider, Gemini CLI, Codex CLI, Windsurf, Copilot, Pi). Scores across 7 capability dimensions plus cost discipline; ships OpenTelemetry-aligned trace artifacts and a Production Readiness Score.
 - [aiignore-cli](https://github.com/yjcho9317/aiignore-cli) - Auto-generates and validates ignore configurations for 7 AI coding tools. Based on bypass test results per tool.
 - [Clearwing](https://github.com/Lazarus-AI/clearwing) - Autonomous vulnerability scanner and source-code hunter. Built on `genai-pyo3`, a native Rust-backed LLM runtime speaking every major provider (Anthropic, OpenAI, OpenRouter, Ollama, LM Studio, Together, Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
 


### PR DESCRIPTION
Adds AWB to the Testing & Security section next to other evaluation/observability tools (Hawkeye, Vet, Eval Marketplace).

AWB benchmarks the AI coding tools already listed under AI Code Editors & IDEs and Terminal & CLI Agents — Claude Code, Cursor, Aider, Gemini CLI, Codex CLI, Windsurf, Copilot, Pi — on 100 real OSS tasks at pinned commit SHAs, scoring across 7 capability dimensions plus derived cost discipline.

- Repo: https://github.com/xmpuspus/ai-workflow-benchmark
- PyPI: https://pypi.org/project/awb/ (v1.2.0)
- MIT licensed, Python 3.11+, `pip install awb`
- v1.2 adds OpenTelemetry-aligned trace artifacts and a Production Readiness Score

Happy to relocate or split into a new "Benchmarks & Evaluation" section if you'd prefer.