### PR TITLE
Add harness-starter-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **552 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **553 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -452,6 +452,7 @@ Tools, frameworks, and autonomous agents for managing AI-assisted development wo
 - [SWE-Fixer](https://github.com/internlm/SWE-Fixer) - A simple yet effective solution for addressing real-world GitHub issues by training open-source LLMs
 - [Spec Kit](https://github.com/github/spec-kit) - Toolkit to help you get started with Spec-Driven Development
 - [Disciplined AI Software Development - Collaborative](https://github.com/Varietyz/Disciplined-AI-Software-Development) - A structured approach for working with AI on development projects. This methodology addresses common issues like code bloat, architectural drift, and context dilution through systematic constraints.
+- [harness-starter-kit](https://github.com/baskduf/harness-starter-kit) - Prompt-first starter kit for turning repeated coding-agent instructions into durable repo rules, knowledge stores, feedback loops, and drift checks.
 - [gac (Git Auto Commit)](https://github.com/cellwebb/gac) - AI-powered git commit message generator that produces high-quality commit messages based on your staged changes automatically.
 - [Memov](https://github.com/memovai/mem) - AI coding version control on top of Git. Track not just what changed, but why it changed.
 - [OpenEvolve](https://github.com/codelion/openevolve) - Turn your LLMs into autonomous code optimizers that discover breakthrough algorithms

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **552個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **553個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -453,6 +453,7 @@ AI支援開発ワークフローを管理するツール、フレームワーク
 - [SWE-Fixer](https://github.com/internlm/SWE-Fixer) - オープンソースLLMをトレーニングすることで現実世界のGitHubイシューに対処するシンプルで効果的なソリューション
 - [Spec Kit](https://github.com/github/spec-kit) - 仕様駆動開発を始めるためのツールキット
 - [Disciplined AI Software Development - Collaborative](https://github.com/Varietyz/Disciplined-AI-Software-Development) - AI開発プロジェクトでの構造化アプローチ。コード肥大化、アーキテクチャドリフト、コンテキスト希釈などの一般的問題に体系的な制約で対処する手法
+- [harness-starter-kit](https://github.com/baskduf/harness-starter-kit) - 繰り返し使うコーディングエージェント向け指示を、永続的なリポジトリルール、知識ストア、フィードバックループ、ドリフトチェックに変換するプロンプトファーストのスターターキット
 - [gac (Git Auto Commit)](https://github.com/cellwebb/gac) - ステージされた変更に基づき高品質なコミットメッセージを自動生成するAI搭載gitコミットメッセージ生成器
 - [Memov](https://github.com/memovai/mem) - Git上のAIコーディングバージョン管理。何が変更されただけでなく、なぜ変更されたかを追跡
 - [Agentless](https://github.com/OpenAutoCoder/Agentless) - ソフトウェア開発問題を自動解決するエージェントレスアプローチ


### PR DESCRIPTION
## 変更内容の要約

Development Workflows & Agents セクションに [harness-starter-kit](https://github.com/baskduf/harness-starter-kit) を追加しました。

## 変更内容

- `README.md` と `README_JA.md` に harness-starter-kit を追加
- ツール総数を 552 個から 553 個に更新

## ツールの概要

harness-starter-kit は、繰り返し使うコーディングエージェント向け指示を、AGENTS.md ルール、知識ストア、フィードバックループ、ドリフトチェックなどの永続的なリポジトリアーティファクトに変換する、プロンプトファーストのスターターキットです。