### PR TITLE
Add RapidNative to AI Code Editors & IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Full-featured AI-powered code editors and integrated development environments.
 - [Nimbalyst](https://nimbalyst.com) - Visual workspace for building with Codex and Claude Code. Session and task management. Visual editing of markdown, mockups, csv, excalidraw, mermaid, code.  
 - [Devin](https://devin.ai/) - An AI coding agent and software engineer that helps developers build better software faster. Parallel cloud agents for serious engineering teams.
 - [Windsurf Editor](https://windsurf.com/editor) - The first agentic IDE, and then some. The Windsurf Editor is where the work of developers and AI truly flow together, allowing for a coding experience that feels like literal magic.
+- [RapidNative](https://rapidnative.com/) - AI-native mobile app builder that turns ideas, sketches, or screenshots into working React Native and Expo apps. Generates production-ready code you can view, edit, and extend, with real-time team collaboration.
 
 ## Terminal & CLI Agents
 


### PR DESCRIPTION
## Adding RapidNative

Submitting [RapidNative](https://rapidnative.com/) to the **AI Code Editors & IDEs** section.

### What it does
AI-native mobile app builder. Describe or sketch your app, watch it build in real time, then ship to App Store / Play Store. Generates production-ready React Native and Expo code that can be viewed, edited, and extended.

### Why this section
Sits naturally alongside existing builder-style entries like bolt.new, Libra AI, Claudable, Devin, and Windsurf Editor. RapidNative is differentiated by its mobile-first React Native focus and sketch-to-app input modality.

### Pricing
Freemium — 20 free credits to start.

Thanks for maintaining this list!