### PR TITLE
Add Easy Orchestration Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **552 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **553 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -223,6 +223,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator for Claude Code, Codex, Cursor agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. TypeScript, MIT.
 - [Asynkor](https://github.com/asynkor/asynkor) - Coordination layer for AI agent teams. File leasing, shared memory, cross-machine sync. One MCP server for Claude Code, Cursor, Windsurf.
 - [evo](https://github.com/evo-hq/evo) - A plugin for Claude Code and Codex that turns your codebase into an autoresearch loop — discovers what to measure, instruments the benchmark, then runs tree search with parallel subagents.
+- [Easy Orchestration Harness](https://github.com/SihyeonJeon/easy-orchestration-harness) - File-backed operating state for long AI-agent projects. Scaffolds roles, event logs, eval fixtures, status reports, and restart handoffs beside Claude Code, Codex, LangGraph, and CrewAI.
 
 ## Code Generation & Automation
 


### PR DESCRIPTION
## 変更内容の要約

Multi-Agent & Orchestrationセクションに[Easy Orchestration Harness](https://github.com/SihyeonJeon/easy-orchestration-harness)を追加しました。

## 変更内容

- Easy Orchestration HarnessをMulti-Agent & Orchestrationセクションに追加
- ツール総数を552個から553個に更新

## ツールの概要

Easy Orchestration Harnessについて

長いAIエージェントプロジェクト向けのファイルベースのoperating stateツールです。Claude Code、Codex、LangGraph、CrewAIなどのワークフローの横で、役割、イベントログ、評価fixture、ステータスレポート、再開用handoffをリポジトリ内に生成します。

