### PR TITLE
Add Wasla

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **552個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **553個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -184,6 +184,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) - AutoGenとCrewAIなどを組み合わせたマルチエージェントLLMシステムの構築・管理向けローコードソリューション
 - [Claude Squad](https://github.com/smtg-ai/claude-squad) - Claude Code、Aider、Codex、OpenCode、Ampなど複数のAIターミナルエージェントを管理
 - [vsync](https://github.com/nicepkg/vsync) - Claude Code、Cursor、OpenCode、Codex間でスキル、MCPサーバー、エージェント、コマンドを自動フォーマット変換で同期
+- [Wasla](https://github.com/The-Untitled-Org/wasla) - Claude Code、Gemini CLI、Codex、OpenCode/OpenClaw、GitHub Copilotワークフロー間でエージェント、MCP設定、スキル、コマンドなどを同期するTypeScript CLI
 - [Claude-Flow v2.0.0 Alpha](https://github.com/ruvnet/claude-flow) - エンタープライズグレードアーキテクチャ、高度スウォーム知能、Claude Codeシームレス統合でゼロから構築
 - [Activepieces](https://github.com/activepieces/activepieces) - AIエージェント＆MCP＆AIワークフロー自動化 • AIエージェント用約400個MCPサーバー • MCP付きAI自動化/AIエージェント • AIワークフロー＆AIエージェント • AIエージェント用MCP
 - [Heurist Agent Framework](https://github.com/heurist-network/heurist-agent-framework) - 推論、ツール使用、メモリ、深度研究、ブロックチェーンインタラクション、MCP、エージェント・アズ・ア・サービスでエージェントを構築する柔軟なマルチインターフェースAIエージェントフレームワーク


### PR DESCRIPTION
## 変更内容の要約

マルチエージェント & オーケストレーションセクションに[Wasla](https://github.com/The-Untitled-Org/wasla)を追加しました。

## 変更内容

- Wasla (https://github.com/The-Untitled-Org/wasla) をマルチエージェント & オーケストレーションセクションに追加
- ツール総数を552個から553個に更新

## ツールの概要

Waslaについて
Claude Code、Gemini CLI、Codex、OpenCode/OpenClaw、GitHub Copilotワークフロー間で、エージェント、MCP設定、スキル、コマンドなどのAI開発アセットを同期するオープンソースのTypeScript CLIです。複数のAIオーケストレーターを使う開発者が、同じ設定やエージェント定義を各ツールで重複管理しなくて済むようにします。