### PR TITLE
Add TWZRD Agent Intel - on-chain trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ AI-powered tools for testing, quality assurance, security analysis, and code cov
 
 Model Context Protocol servers and integrations for enhanced AI capabilities.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - On-chain trust scoring MCP server for AI agent wallets on Solana. Verify agent identity before x402 micropayments. Free tools: score_agent, preflight_check.
 - [GitHub MCP Server](https://github.com/github/github-mcp-server) - The GitHub MCP Server is a Model Context Protocol (MCP) server that provides seamless integration with GitHub APIs
 - [AWS MCP Servers](https://github.com/awslabs/mcp) - A suite of specialized MCP servers that bring AWS best practices directly to your development workflow
 - [MCP C# SDK](https://github.com/modelcontextprotocol/csharp-sdk) - The official C# SDK for Model Context Protocol servers and clients, maintained by Microsoft


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the MCP Servers & Integrations section.

TWZRD Agent Intel is an MCP server providing on-chain trust scoring for AI agent wallets on Solana. Enables AI-driven development tools to verify agent wallet identity before x402 micropayments.

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:**
- `score_agent(wallet)` — Trust score + on-chain reputation for any Solana wallet
- `preflight_check(wallet)` — Validates wallet before payment acceptance
- `get_trust_receipt(wallet)` — Cryptographic on-chain trust receipt (paid, x402)