### PR TITLE
Add Loki Mode to Terminal & CLI Agents

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **552個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **553個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -106,6 +106,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Caliber](https://github.com/caliber-ai-org/ai-setup) - プロジェクトをフィンガープリントし、AIエージェント設定（CLAUDE.md、.cursor/rules/、AGENTS.md、スキル）を生成・同期するCLI。設定品質をスコアリングし、ドキュメントの同期を維持。Claude Code、Cursor、Copilot、Codex対応
 - [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) - SnowflakeのAIコーディングエージェントCLI。SQL、Python、データエンジニアリングワークフローをSnowflake接続機能とともに提供
 - [pi coding agent](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) - AIエージェントツールキット：コーディングエージェントCLI、統合LLM API、TUI＆Web UIライブラリ、Slackボット、vLLMポッド
+- [Loki Mode](https://github.com/asklokesh/loki-mode) - 仕様から製品までを自律的に構築するCLIエージェント。検証ゲートを備え、ブラインドレビュー方式の完了協議会とエビデンスチェックを通過するまで作業を完了とみなさない。ブラウンフィールド対応の`loki heal`、ローカルファースト（自前のAPIキー）、26ツールのMCPサーバー、AGENTS.md読み込み対応。ソースアベイラブル（BUSL-1.1）
 
 ## IDE拡張機能
 


### PR DESCRIPTION
## 変更内容の要約

ターミナル & CLIエージェントセクションに[Loki Mode](https://github.com/asklokesh/loki-mode)を追加しました。

## 変更内容

- Loki Mode (https://github.com/asklokesh/loki-mode) をターミナル & CLIエージェントセクションに追加
- ツール総数を552個から553個に更新
- CONTRIBUTING.mdの指示に従いREADME_JA.mdを更新

## ツールの概要

Loki Modeについて
仕様（PRD、GitHub issue、OpenAPIドキュメント、または一行の概要）から製品までを自律的に構築する、ソースアベイラブル（BUSL-1.1）なCLIコーディングエージェント。最大の特徴は完了検証ゲートで、ブラインドレビュー方式の完了協議会とエビデンスチェックが「完了」を却下できるため、モデルの自己申告だけで作業を完了とはみなさない。ブラウンフィールドコードは`loki heal`で対応し、ローカルファースト（自前のAPIキー、データ送出なし）で動作し、26ツールのMCPサーバーを備え、AGENTS.mdを読み込む。プロバイダー非依存（Claude Code、OpenAI Codex CLI、Cline、Aider）。現在のリリースはv7.27.0。リンクは有効で、重複はありません。
