### PR TITLE
Add Cate to AI Code Editors & IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **567 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **568 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -48,6 +48,7 @@ Full-featured AI-powered code editors and integrated development environments.
 - [SpaceManager](https://github.com/NEWBIE0413/SpaceManager) - A terminal-centric IDE for the age of AI agents.
 - [SquirlIDE](https://github.com/krishnak19a-del/SquirlIDE) - A lightweight, cross-platform code editor built using Tauri (Rust) for the backend and ReactJS for the frontend, with integration for large language model (LLM) calls using Gemini API for code assistance and text generation.
 - [Frontman](https://github.com/frontman-ai/frontman) - Open-source AI coding agent that lives in your browser. Hooks into your dev server as middleware, sees live DOM, component tree, CSS, routes, and server logs. Click any element, describe changes, get real source code edits with hot reload.
+- [Cate](https://github.com/0-AI-UG/cate) - Open source IDE on an infinite zoomable canvas. Editor, terminal, browser, and AI agent (Claude Code) panels are arranged in spatial workspaces instead of tabs. Built with Electron, React, and TypeScript
 - [Nimbalyst](https://nimbalyst.com) - Visual workspace for building with Codex and Claude Code. Session and task management. Visual editing of markdown, mockups, csv, excalidraw, mermaid, code.  
 - [Devin](https://devin.ai/) - An AI coding agent and software engineer that helps developers build better software faster. Parallel cloud agents for serious engineering teams.
 - [Windsurf Editor](https://windsurf.com/editor) - The first agentic IDE, and then some. The Windsurf Editor is where the work of developers and AI truly flow together, allowing for a coding experience that feels like literal magic.

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **567個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **568個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -48,6 +48,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [SpaceManager](https://github.com/NEWBIE0413/SpaceManager) - AIエージェント時代のターミナル中心IDE
 - [SquirlIDE](https://github.com/krishnak19a-del/SquirlIDE) - Tauri（Rust）をバックエンド、ReactJSをフロントエンドに使用した軽量クロスプラットフォームコードエディタ。コードアシスタンスとテキスト生成のためのGemini API経由のLLM統合を搭載
 - [Frontman](https://github.com/frontman-ai/frontman) - ブラウザ上で動作するオープンソースAIコーディングエージェント。ミドルウェアとして開発サーバーに接続し、ライブDOM、コンポーネントツリー、CSS、ルート、サーバーログを認識。任意の要素をクリックして変更を自然言語で記述すると、ホットリロード付きでソースコードを編集
+- [Cate](https://github.com/0-AI-UG/cate) - 無限ズームキャンバス上のオープンソースIDE。エディタ、ターミナル、ブラウザ、AIエージェント（Claude Code）のパネルをタブの代わりに空間的に配置。Electron、React、TypeScriptで構築
 - [Nimbalyst](https://nimbalyst.com) - CodexとClaude Codeで構築するためのビジュアルワークスペース。セッション・タスク管理、マークダウン・モックアップ・CSV・Excalidraw・Mermaid・コードのビジュアル編集
 - [Devin](https://devin.ai/) - 開発者がより良いソフトウェアをより速く構築するためのAIコーディングエージェント兼ソフトウェアエンジニア。本格的なエンジニアリングチーム向けの並列クラウドエージェント
 - [Windsurf Editor](https://windsurf.com/editor) - 初のエージェント型IDE。開発者とAIの作業が真に融合し、まるで魔法のようなコーディング体験を実現


### PR DESCRIPTION
## Summary / 変更内容の要約

Added Cate to the AI Code Editors & IDEs section. / AIコードエディタ & IDEセクションにCateを追加しました。

## Changes / 変更内容

```text
- Added Cate (https://github.com/0-AI-UG/cate) to the AI Code Editors & IDEs section
  Cate (https://github.com/0-AI-UG/cate) をAIコードエディタ & IDEセクションに追加
- Updated the total tool count
  ツール総数を更新
```

## Tool Overview / ツールの概要

```text
About Cate:
An open source desktop IDE built on an infinite zoomable canvas. Monaco editors,
xterm.js terminals, embedded browsers, and AI agent (Claude Code) panels float in
spatial workspaces instead of tabs. Panels can dock, split, or detach into separate
windows, and layout persists per project. Electron + React + TypeScript, MIT
licensed, runs on macOS, Windows, and Linux.

Cateについて：
無限ズームキャンバス上に構築されたオープンソースのデスクトップIDE。Monacoエディタ、
xterm.jsターミナル、組み込みブラウザ、AIエージェント（Claude Code）パネルをタブの
代わりに空間的に配置できる。パネルはドック、分割、別ウィンドウへの分離が可能で、
レイアウトはプロジェクトごとに保存される。Electron + React + TypeScript製、MIT
ライセンス、macOS・Windows・Linux対応。
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
