### PR TITLE
Add Source Trace to Git & Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ Tools for analyzing, searching, and understanding codebases.
 Specialized AI tools for specific development domains and tasks.
 
 ### Git & Version Control
+- [Source Trace](https://srctrace.com) - AI git blame for every commit: see which lines came from AI and which model wrote them. Compare models by amount of code written pre-commit, committed, and survived in codebase. Teams can use dashboard to track adoption and AI metrics. Zero-config VS Code extension, no git or agent hooks required.
 - [ai-commit-tool](https://github.com/awkwardlysocial/ai-commit-tool) - A CLI tool that generates AI-based git commit messages
 - [commit](https://github.com/wajeht/commit) - Generate conventional commits with ai
 - [lazycommit](https://github.com/m7medVision/lazycommit) - Using AI to generate commit message suggestions

--- a/README_JA.md
+++ b/README_JA.md
@@ -534,6 +534,7 @@ AI支援開発ワークフローを管理するツール、フレームワーク
 特定の開発ドメインとタスク向けの専門AIツール。
 
 ### Git・バージョン管理
+- [Source Trace](https://srctrace.com) - コミットごとにAI gitブレームを提供：どの行がAIによるものか、どのモデルが書いたかを表示。コード生成量・コミット済み・コードベースに残存した量でモデルを比較。チームダッシュボードで導入状況とAIメトリクスを追跡。設定不要のVS Code拡張機能。
 - [ai-commit-tool](https://github.com/awkwardlysocial/ai-commit-tool) - AIベースgitコミットメッセージを生成するCLIツール
 - [commit](https://github.com/wajeht/commit) - AIで従来型コミットを生成
 - [lazycommit](https://github.com/m7medVision/lazycommit) - AIを使用してコミットメッセージ提案を生成


### PR DESCRIPTION
<!---
# For details on how to write a PR, see / 書き方については以下のプルリクエストを参照

https://github.com/eltociear/awesome-AI-driven-development/pull/2

Please include a summary, the changes made, and an overview of the tool.
プルリクエストには要約、変更内容、ツールの概要を書くこと。
-->

## Summary / 変更内容の要約

Added Source Trace

Source Trace adds AI Git Blame, and model comparison - based on how much code is written/committed/later deleted. VS Code extension has git blame decoration, and commit history view. Both VS Code extensions and standalone CLI agents are supported: Claude, Codex, Opencode, etc.

## Changes / 変更内容

<!-- Example / 書き方の例: -->

```text
- Added Source Trace
```

## Tool Overview / ツールの概要

<!-- Example / 書き方の例: -->

```text
Source Trace adds AI Git Blame, and model comparison - based on how much code is written/committed/later deleted. VS Code extension has git blame decoration, and commit history view. Both VS Code extensions and standalone CLI agents are supported: Claude, Codex, Opencode, etc.

We built Source Trace, so we can know which agent/model wrote exactly which line of code - e.g. lines 10-15 added by claude with Sonnet 4.6 model. We found that some models are producing low-quality code, so also added dashboard to show "survival rate" per model - e.g. Grok Fast writes 1000 lines, but only 500 survive to commit.

https://srctrace.com/


Source TraceはAI Git Blameとモデル比較機能を提供します。コードがどれだけ書かれ・コミットされ・後に削除されたかに基づいてモデルを比較できます。VS Code拡張機能にはgitブレーム装飾とコミット履歴ビューが含まれており、VS Code拡張機能とスタンドアロンCLIエージェン（Claude、Codex、Opencodeなど）の両方をサポートしています。

Source Traceを構築した目的は、どのエージェント/モデルが正確にどの行を書いたかを把握することです。例えば「10〜15行目はSonnet 4.6モデルのClaudeが追加」といった情報が得られます。一部のモデルが低品質なコードを生成していることがわかったため、モデルごとの「生存率」を示すダッシュボードも追加しました。例えばGrok
  Fastは1000行書いても、コミットまで残るのは500行だけといったケースです。

  https://srctrace.com/
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
