### PR TITLE
Add Roblox GUI Maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **572 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **573 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -256,6 +256,7 @@ Tools for generating code, automating development tasks, and creating project te
 - [Vibe Coding a Full-Stack Budget App](https://github.com/wasp-lang/vibe-coding-video) - Vibe Coding Full-stack App Starter Template
 - [Tour of Heroes API](https://github.com/0GiS0/tour-of-heroes-with-gh-copilot-coding-agent) - A REST API for managing superheroes, implemented with Node.js and TypeScript. This project provides a simple backend for the "Tour of Heroes" application with endpoints to get, create, update, and delete hero data.
 - [AI Website Builder](https://github.com/Ratna-Babu/Ai-Website-Builder) - This AI-powered website builder transforms natural language prompts into fully functional React components using Next.js, Tailwind CSS, and Gemini AI.
+- [Roblox GUI Maker](https://robloxguimaker.dev/) - Web tool for planning Roblox Studio ScreenGui hierarchies, HUD and menu layouts, and Lua UI starter code from prompts.
 - [Compose-Lang](https://github.com/darula-hpp/compose-lang) - An LLM-assisted compiler for architecture specifications. Define your application in structured .compose files, and the compiler generates framework-specific code through LLM-powered code generation with reproducible builds via caching.
 - [Shadow Code](https://github.com/adifyr/shadow-code) - an AI coding technique that involves transforming human-written pseudocode to clean, accurate & production-ready code in the target language. (At least, that's what I've told the AI to do in the system prompt.)
 - [InsForge](https://github.com/InsForge/InsForge) - A backend development platform built for AI coding agents and AI code editors.

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **572個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **573個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -255,6 +255,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Tour of Heroes API](https://github.com/0GiS0/tour-of-heroes-with-gh-copilot-coding-agent) - スーパーヒーローを管理するREST API、Node.jsとTypeScriptで実装。ヒーローデータの取得、作成、更新、削除のエンドポイントを備えた「Tour of Heroes」アプリケーション用シンプルバックエンド
 - [Legacy2Modern (L2M)](https://github.com/astrio-ai/legacy2modern) - レガシーCOBOLコードを現代的でメンテナンス可能なPythonアプリケーションに変換するオープンソースエンジン
 - [AI Website Builder](https://github.com/Ratna-Babu/Ai-Website-Builder) - 自然言語プロンプトをNext.js、Tailwind CSS、Gemini AIを使用して完全に機能するReactコンポーネントに変換するAI搭載ウェブサイトビルダー
+- [Roblox GUI Maker](https://robloxguimaker.dev/) - プロンプトからRoblox StudioのScreenGui階層、HUDとメニュー配置、Lua UIスターターコード案を計画するWebツール
 - [Compose-Lang](https://github.com/darula-hpp/compose-lang) - アーキテクチャ仕様用のLLM支援コンパイラ。構造化された.composeファイルでアプリケーションを定義し、キャッシュによる再現可能なビルドでLLM駆動のコード生成を通じてフレームワーク固有のコードを生成
 - [RooFlow Cookiecutter Template](https://github.com/hheydaroff/RooFlow-Cookiecutter) - RoocodeにRooflowを簡単に適用するテンプレート
 - [Vibe Coding a Full-Stack Budget App](https://github.com/wasp-lang/vibe-coding-video) - Vibe Codingフルスタックアプリスターターテンプレート


### PR DESCRIPTION
## Summary / 変更内容の要約\n\nAdded Roblox GUI Maker to the Code Generation & Automation section in both README.md and README_JA.md.\n\n## Changes / 変更内容\n\n- Added Roblox GUI Maker (https://robloxguimaker.dev/) to Code Generation & Automation\n- Updated the total tool count from 572 to 573 in both README files\n\n## Tool Overview / ツールの概要\n\nRoblox GUI Maker is a web tool for planning Roblox Studio ScreenGui hierarchies, HUD and menu layouts, and Lua UI starter code from prompts. It is aimed at Roblox creators prototyping UI before implementing it in Studio.\n\n## Validation\n\n- git diff --check\n- README smoke check confirmed one Roblox GUI Maker entry in each README\n\n## Checklist / チェックリスト\n\n- [x] The entry is added to both README.md and README_JA.md\n- [x] All links are valid and reachable\n- [x] The tool is related to AI-driven development