### PR TITLE
Add agent-qa

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **574 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **575 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -267,6 +267,7 @@ AI-powered tools for testing, quality assurance, security analysis, and code cov
 
 - [qodo-cover](https://github.com/qodo-ai/qodo-cover) - An AI-Powered Tool for Automated Test Generation and Code Coverage Enhancement! 💻🤖🧪🐞
 - [shortest](https://github.com/anti-work/shortest) - QA via natural language AI tests
+- [agent-qa](https://github.com/vostride/agent-qa) - Self-improving QA agent for web and mobile apps with natural-language tests, run memory, UI-change adaptation, and regression detection before shipping.
 - [mutahunter](https://github.com/codeintegrity-ai/mutahunter) - Open Source, Language Agnostic Automatic Test Generation + LLM Mutation Testing
 - [testzeus-hercules](https://github.com/test-zeus-ai/testzeus-hercules) - Hercules is the world's first open-source testing agent, built to handle the toughest testing tasks so you don't have to
 - [ghostest](https://github.com/ryooo/ghostest) - Output test code using LLM agents

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,7 +3,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **574個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **575個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -268,6 +268,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 
 - [qodo-cover](https://github.com/qodo-ai/qodo-cover) - 自動テスト生成とコードカバレッジ向上向けAI搭載ツール！💻🤖🧪🐞
 - [shortest](https://github.com/anti-work/shortest) - 自然言語AIテストによるQA
+- [agent-qa](https://github.com/vostride/agent-qa) - Web/モバイルアプリ向けの自己改善QAエージェント。自然言語テスト、実行メモリ、UI変化への適応、出荷前のリグレッション検出に対応。
 - [mutahunter](https://github.com/codeintegrity-ai/mutahunter) - オープンソース、言語非依存自動テスト生成 + LLMミューテーションテスト
 - [testzeus-hercules](https://github.com/test-zeus-ai/testzeus-hercules) - 最も困難なテスト業務を処理する世界初のオープンソーステストエージェント、Hercules
 - [ghostest](https://github.com/ryooo/ghostest) - LLMエージェントを使用してテストコードを出力


### PR DESCRIPTION
## Summary / 変更内容の要約

Added agent-qa to the Testing & Security section in both README files.

## Changes / 変更内容

- Added agent-qa (https://github.com/vostride/agent-qa) to the Testing & Security section
  agent-qa (https://github.com/vostride/agent-qa) をTesting & Securityセクションに追加
- Updated the total tool count from 574 to 575
  ツール総数を574個から575個に更新

## Tool Overview / ツールの概要

About agent-qa:
agent-qa is a self-improving QA agent for web and mobile apps. It lets teams write tests in natural language, keeps run memory, adapts to UI changes, and catches regressions before shipping.

agent-qaについて：
agent-qaはWeb/モバイルアプリ向けの自己改善QAエージェントです。自然言語でテストを書き、実行メモリを保持し、UI変化に適応し、出荷前にリグレッションを検出できます。

## Checklist / チェックリスト

- [x] The entry is added to both README.md and README_JA.md / エントリを README.md と README_JA.md の両方に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している

## Checks

- curl -I https://github.com/vostride/agent-qa
- git diff --check