### PR TITLE
Add DevIntern to Project & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **587 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **588 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -443,6 +443,7 @@ Tools for project management, documentation, and knowledge organization in AI-dr
 - [AI Context Templates](https://github.com/MrDwarf7/ai-context-templates) - Free CLAUDE.md, Cursor rules, and PRP templates for common project types. 5 ready-to-use packs that make AI coding assistants actually useful.
 - [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.
 - [url-to-md](https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup.
+- [DevIntern](https://github.com/getdevintern/devintern) - A tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests with the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode), running on your machines with your own model keys.
 
 ## Language Models & Engines
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **587個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **588個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -444,6 +444,7 @@ AI駆動開発におけるプロジェクト管理、ドキュメント、ナレ
 - [AI Context Templates](https://github.com/MrDwarf7/ai-context-templates) - 一般的なプロジェクトタイプ向けの無料のCLAUDE.md、Cursorルール、PRPテンプレート集。すぐに使える5つのパックでAIコーディングアシスタントを実用化
 - [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - AIコーディングコンテキストファイル（CLAUDE.md、.cursorrules、AGENTS.md）のセキュリティ問題、構造的問題、AIアンチパターンを検出するGitHub Action
 - [url-to-md](https://github.com/MrDwarf7/url-to-md) - 任意のURLをLLM向けのクリーンなMarkdownに変換。無料API、サインアップ不要
+- [DevIntern](https://github.com/getdevintern/devintern) - Jira、Linear、Trello、Asana、Azure DevOps、GitHub Issues、またはMarkdownファイルからチケットを取得し、任意のコーディングエージェント（Claude Code、Codex、Cursor、OpenCode）でセルフレビュー済みのプルリクエストに変換するツール。自分のマシン上で自分のモデルキーを使って動作します
 
 ## 言語モデル & エンジン
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added DevIntern to the Project & Knowledge Management section. / Project & Knowledge Managementセクションに DevIntern を追加しました。

## Changes / 変更内容

```text
- Added DevIntern (https://github.com/getdevintern/devintern) to the Project & Knowledge Management section, in both README.md and README_JA.md
  DevIntern (https://github.com/getdevintern/devintern) をProject & Knowledge Managementセクション（README.md と README_JA.md の両方）に追加
- Updated the total tool count from 587 to 588 in both files
  両ファイルのツール総数を587個から588個に更新
```

## Tool Overview / ツールの概要

```text
About DevIntern:
A tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps,
GitHub Issues, or markdown files and turns them into self-reviewed pull requests
using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode),
running on your machines with your own model keys. A feasibility gate flags vague
tickets back to the tracker with questions, and an optional unattended mode
schedules ticket pickup and turns PR review comments into commits. A companion
devpm tool creates well-specified, codebase-grounded tickets from rough prompts.
Source-available under FSL-1.1; free for interactive use.

DevInternについて：
Jira、Linear、Trello、Asana、Azure DevOps、GitHub Issues、またはMarkdownファイルから
チケットを取得し、任意のコーディングエージェント（Claude Code、Codex、Cursor、OpenCode）を
使ってセルフレビュー済みのプルリクエストに変換するツール。自分のマシン上で自分のモデルキーを
使って動作します。実現可能性ゲートが曖昧なチケットを質問付きでトラッカーに差し戻し、
オプションの無人モードではチケット取得のスケジュール実行やPRレビューコメントのコミット化が
可能です。付属のdevpmツールは、大まかなプロンプトからコードベースに基づいた明確なチケットを
作成します。FSL-1.1のソースアベイラブルライセンスで、対話的な利用は無料です。
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
