### PR TITLE
Add Agent Teams AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **588 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **589 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -234,6 +234,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Universal Fusion Plugin 🧠](https://github.com/ProxyAyush/antigravity-fusion-plugin) - Multi-model fusion for Google Antigravity CLI. Ask multiple models (e.g. Gemini 3.5 Flash, Gemini 3.1 Pro, etc.) in parallel, then judge their answers into one and act on it.
 - [Swarm](https://github.com/DheerG/swarms) - This plugin gives users a few commands that greatly improve results using agent teams/swarms with outcome based directives. It works well with both coding and non-coding tasks.
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - Runs a planner, an implementer, and independent validators in isolated environments (local, git worktree, or Docker), looping until a change is verified or rejected with reproducible failures. Works with Claude, Codex, Gemini, and OpenCode CLIs.
+- [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes.
 
 ## Code Generation & Automation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **588個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **589個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -234,6 +234,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Universal Fusion Plugin 🧠](https://github.com/ProxyAyush/antigravity-fusion-plugin) - Google Antigravity CLI向けのマルチモデルフュージョン。複数のモデル（例：Gemini 3.5 Flash、Gemini 3.1 Proなど）に並列で問い合わせ、その回答を1つに統合・評価して実行する
 - [Swarm](https://github.com/DheerG/swarms) - 成果ベースの指示でエージェントチーム/スワームを活用し、結果を大幅に改善するコマンド群を提供するプラグイン。コーディングタスクにも非コーディングタスクにもよく機能する。
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - プランナー、実装者、独立した検証者を隔離環境（ローカル、git worktree、Docker）で実行し、変更が検証されるか再現可能な失敗で却下されるまでループする。Claude、Codex、Gemini、OpenCodeの各CLIに対応。
+- [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - タスク委譲、エージェント間メッセージング、カンバンボード、コードレビューを備え、複数のエージェント実行環境に対応するオープンソースの自律型コーディングエージェントチーム向けデスクトップオーケストレーター。
 
 ## コード生成 & 自動化
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added Agent Teams AI to the Multi-Agent & Orchestration section in both language versions.

Agent Teams AIを英語版と日本語版のマルチエージェント & オーケストレーションセクションに追加しました。

## Changes / 変更内容

- Added the entry to `README.md` and `README_JA.md`
- Updated the total tool count from 588 to 589

## Tool Overview / ツールの概要

Agent Teams AI is an open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes.

Agent Teams AIは、タスク委譲、エージェント間メッセージング、カンバンボード、コードレビューを備え、複数のエージェント実行環境に対応するオープンソースのデスクトップオーケストレーターです。

## Checklist / チェックリスト

- [x] Added to both README files
- [x] Verified the project link
- [x] Confirmed the tool is related to AI-driven development
- [x] Checked for an existing entry and open pull request

Disclosure: I maintain Agent Teams AI.