### PR TITLE
Add Scopeglass to Prompt & Context Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,7 @@ Specialized AI tools for specific development domains and tasks.
 - [Nomad's AI Prompt Library](https://github.com/TechNomadCode/Open-Source-Prompt-Library) - This repository serves as a central place to store, organize, and share effective prompts for various AI models
 - [zoltraak](https://github.com/dai-motoki/zoltraak) - A prompt compiler system that converts natural language into an execution language
 - [cmpr](https://github.com/inimino/cmpr) - Program in English! LLM-enabled programming framework
+- [Scopeglass](https://github.com/zackabrah/scopeglass) - Local CLI that inspects the AGENTS.md chain a coding agent inherits: precedence, line-level provenance, token estimates, and checks for broken references, duplicates, and conflicts
 
 ### Copilot Extensions & Alternatives
 - [copilot-more](https://github.com/jjleng/copilot-more) - $10/month GPT-4o and Claude-3.5-Sonnet APIs for coding and beyond


### PR DESCRIPTION
Disclosure: I'm the author of Scopeglass.

Adds Scopeglass: a local CLI that inspects the AGENTS.md chain a coding
agent inherits — precedence, line-level provenance, token estimates, and
checks for broken references, duplicates, and conflicts. MIT, CI-friendly.