### PR TITLE
Add Agent-Ready Repo Auditor to Testing & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **588 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **589 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -288,6 +288,7 @@ AI-powered tools for testing, quality assurance, security analysis, and code cov
 - [VulnViper](https://github.com/anshulyadav1976/VulnViper) - An intelligent security auditing tool designed to help developers identify and understand potential vulnerabilities in their Python codebases
 - [codegate](https://github.com/stacklok/codegate) - A local gateway that makes AI coding assistants safer
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - 33 evidence-backed checks for AI-friendly repos — file structure, instruction quality, build setup, session continuity, and security posture. Claude Code plugin with auto-fix.
+- [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) - Dependency-free CLI, library, and GitHub Action that scores public repository evidence for Codex, Claude Code, Copilot, and Cursor readiness without cloning or executing code.
 - [vibelint](https://github.com/mithranm/vibelint) - Make codebases more LLM friendly
 - [Vibe Security](https://github.com/astoj/vibe-security) - A comprehensive security checklist for vibe coders
 - [Strix](https://github.com/usestrix/strix) - Open-source AI hackers for your apps

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **588個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **589個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -289,6 +289,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [VulnViper](https://github.com/anshulyadav1976/VulnViper) - Pythonコードベース内の潜在的脆弱性の特定と理解を支援するインテリジェントセキュリティ監査ツール
 - [codegate](https://github.com/stacklok/codegate) - AIコーディングアシスタントを安全にするローカルゲートウェイ
 - [AgentLint](https://github.com/0xmariowu/AgentLint) - AIフレンドリーなリポジトリのための33のエビデンスベースチェック — ファイル構造、指示品質、ビルド設定、セッション継続性、セキュリティ態勢。Claude Codeプラグインで自動修正対応
+- [Agent-Ready Repo Auditor](https://github.com/wrightops-ai/agent-ready-repo-auditor) - 公開リポジトリをクローンしたりコードを実行したりせず、Codex、Claude Code、Copilot、Cursor向けの準備状況をエビデンスに基づいて採点する、依存関係のないCLI、ライブラリ、GitHub Action。
 - [vibelint](https://github.com/mithranm/vibelint) - コードベースをLLMフレンドリーにする
 - [Vibe Security](https://github.com/astoj/vibe-security) - Vibeコーダー向け包括的セキュリティチェックリスト
 - [Strix](https://github.com/usestrix/strix) - 「AIハッカー」として機能するオープンソースのセキュリティエージェント。開発ワークフローに統合し、アプリケーションの脆弱性を能動的にテスト・発見する。ローカルで実行し、継続的なセキュリティテストを自動化できる


### PR DESCRIPTION
## Summary / 変更内容の要約

Added Agent-Ready Repo Auditor to the Testing & Security section in both README files. / Agent-Ready Repo Auditorを両方のREADMEのテスト & セキュリティセクションに追加しました。

## Changes / 変更内容

- Added Agent-Ready Repo Auditor (https://github.com/wrightops-ai/agent-ready-repo-auditor) to Testing & Security in README.md and README_JA.md
  Agent-Ready Repo AuditorをREADME.mdとREADME_JA.mdのテスト & セキュリティセクションに追加
- Updated the total tool count from 588 to 589 in both files
  両ファイルのツール総数を588個から589個に更新

## Tool Overview / ツールの概要

Agent-Ready Repo Auditor is an MIT-licensed, dependency-free CLI, library, and GitHub Action that scores public repository evidence for Codex, Claude Code, Copilot, and Cursor readiness. It inspects a pinned public revision without cloning the repository or executing its code. I maintain the listed project through WrightOps AI.

Agent-Ready Repo Auditorは、Codex、Claude Code、Copilot、Cursor向けの公開リポジトリの準備状況をエビデンスに基づいて採点する、MITライセンスの依存関係のないCLI、ライブラリ、GitHub Actionです。リポジトリをクローンしたりコードを実行したりせず、固定された公開リビジョンを検査します。掲載プロジェクトはWrightOps AIを通じて管理しています。

## Checklist / チェックリスト

- [x] The entry is added to **both** README.md and README_JA.md / エントリをREADME.mdとREADME_JA.mdの**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している

## Checks

- `git diff --check`
- Exact count and single-entry assertions in both files
- Product repository returned HTTP 200