### PR TITLE
Add Agentlas OS to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **593 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **594 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -235,6 +235,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Swarm](https://github.com/DheerG/swarms) - This plugin gives users a few commands that greatly improve results using agent teams/swarms with outcome based directives. It works well with both coding and non-coding tasks.
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - Runs a planner, an implementer, and independent validators in isolated environments (local, git worktree, or Docker), looping until a change is verified or rejected with reproducible failures. Works with Claude, Codex, Gemini, and OpenCode CLIs.
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes.
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) for building or borrowing specialist agents, composing teams, and running them across Claude Code, Codex, Gemini CLI, Cursor, and local models with permission and verification gates.
 
 ## Code Generation & Automation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **593個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **594個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -235,6 +235,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Swarm](https://github.com/DheerG/swarms) - 成果ベースの指示でエージェントチーム/スワームを活用し、結果を大幅に改善するコマンド群を提供するプラグイン。コーディングタスクにも非コーディングタスクにもよく機能する。
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - プランナー、実装者、独立した検証者を隔離環境（ローカル、git worktree、Docker）で実行し、変更が検証されるか再現可能な失敗で却下されるまでループする。Claude、Codex、Gemini、OpenCodeの各CLIに対応。
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - タスク委譲、エージェント間メッセージング、カンバンボード、コードレビューを備え、複数のエージェント実行環境に対応するオープンソースの自律型コーディングエージェントチーム向けデスクトップオーケストレーター。
+- [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - 専門エージェントの構築・借用、チーム編成、Claude Code・Codex・Gemini CLI・Cursor・ローカルモデルでの実行に対応し、権限と検証ゲートを備えたローカルファーストのAgent Operation Environment (AOE)。
 
 ## コード生成 & 自動化
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added Agentlas OS to the Multi-Agent & Orchestration section in both language editions.
英語版・日本語版のマルチエージェント & オーケストレーションセクションにAgentlas OSを追加しました。

## Changes / 変更内容

- Added Agentlas OS to `README.md` and `README_JA.md`
- Updated the total tool count from 593 to 594 in both files
- Agentlas OSを`README.md`と`README_JA.md`に追加
- 両ファイルのツール総数を593個から594個に更新

## Tool Overview / ツールの概要

Agentlas OS is an Apache-2.0, local-first Agent Operation Environment (AOE) for building or borrowing specialist agents, composing teams, and running them across Claude Code, Codex, Gemini CLI, Cursor, and local models with permission and verification gates.

Agentlas OSは、専門エージェントの構築・借用、チーム編成、Claude Code・Codex・Gemini CLI・Cursor・ローカルモデルでの実行に対応し、権限と検証ゲートを備えたApache-2.0のローカルファーストAgent Operation Environment (AOE)です。

Disclosure: I am submitting this on behalf of Agentlas.

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
