### PR TITLE
Add Garcon to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **594 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **595 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -236,6 +236,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - Runs a planner, an implementer, and independent validators in isolated environments (local, git worktree, or Docker), looping until a change is verified or rejected with reproducible failures. Works with Claude, Codex, Gemini, and OpenCode CLIs.
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) for building or borrowing specialist agents, composing teams, and running them across Claude Code, Codex, Gemini CLI, Cursor, and local models with permission and verification gates.
+- [Garcon](https://github.com/cfal/garcon) - Self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with integrated terminal, file editing, diff review, Git/PR workflows, mobile approvals, scheduling, and cross-agent transfers.
 
 ## Code Generation & Automation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **594個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **595個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -236,6 +236,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [zeroshot](https://github.com/the-open-engine/zeroshot) - プランナー、実装者、独立した検証者を隔離環境（ローカル、git worktree、Docker）で実行し、変更が検証されるか再現可能な失敗で却下されるまでループする。Claude、Codex、Gemini、OpenCodeの各CLIに対応。
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - タスク委譲、エージェント間メッセージング、カンバンボード、コードレビューを備え、複数のエージェント実行環境に対応するオープンソースの自律型コーディングエージェントチーム向けデスクトップオーケストレーター。
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - 専門エージェントの構築・借用、チーム編成、Claude Code・Codex・Gemini CLI・Cursor・ローカルモデルでの実行に対応し、権限と検証ゲートを備えたローカルファーストのAgent Operation Environment (AOE)。
+- [Garcon](https://github.com/cfal/garcon) - ブラウザとモバイルで利用できるセルフホスト型ワークスペース。Claude Code、Codex、Cursor Agent、OpenCode、Amp、Droid、Pi の並列セッションを実行・操作し、統合ターミナル、ファイル編集、差分レビュー、Git/PRワークフロー、モバイル承認、スケジュール実行、エージェント間転送を提供。
 
 ## コード生成 & 自動化
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added Garcon to the Multi-Agent & Orchestration section in both language editions.
英語版・日本語版のマルチエージェント & オーケストレーションセクションにGarconを追加しました。

## Changes / 変更内容

- Added Garcon to `README.md` and `README_JA.md`
- Updated the total tool count from 594 to 595 in both files
- Garconを`README.md`と`README_JA.md`に追加
- 両ファイルのツール総数を594個から595個に更新

## Tool Overview / ツールの概要

Garcon is a GPL-3.0 self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions. It includes terminal/files/diffs, Git and pull-request workflows, mobile approvals, scheduling, and cross-agent transfers.

GarconはGPL-3.0のセルフホスト型ブラウザ・モバイルワークスペースです。Claude Code、Codex、Cursor Agent、OpenCode、Amp、Droid、Piの並列セッションに対応し、ターミナル、ファイル、差分レビュー、Git/PRワークフロー、モバイル承認、スケジュール実行、エージェント間転送を提供します。

Disclosure: I maintain Garcon.

## Checklist / チェックリスト

- [x] The entry is added to both `README.md` and `README_JA.md` / エントリを両方に追加した
- [x] All links are valid and reachable / すべてのリンクを確認した
- [x] The tool is related to AI-driven development / AI駆動開発に関連している
