### PR TITLE
Add backlog-as-data (Project & Knowledge Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Tools for project management, documentation, and knowledge organization in AI-dr
 - [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.
 - [url-to-md](https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup.
 - [DevIntern](https://github.com/getdevintern/devintern) - A tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests with the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode), running on your machines with your own model keys.
+- [backlog-as-data](https://github.com/giboulz/backlog-as-data) - Spec-driven backlog for Claude Code where the backlog is git data: tickets as YAML frontmatter in spec files, per-ticket model/effort/review dosing, git-flow lifecycle hooks, and a fresh-context review gate.
 
 ## Language Models & Engines
 


### PR DESCRIPTION
Adds [backlog-as-data](https://github.com/giboulz/backlog-as-data) to the Project & Knowledge Management section.

It is a spec-driven backlog system for Claude Code, published as a reference implementation extracted from a daily-driven personal setup: tickets live as YAML frontmatter inside the spec files themselves (status is a field, never a location), each ticket is matured with a per-ticket model/effort/review triplet before any agent runs, the todo->wip->merged->shipped lifecycle is applied by hooks keyed on conventional commits, and code review is done by fresh-context sub-agents with orchestrator-held evidence.

One line appended at the end of the section, matching the existing entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)