### PR TITLE
Add fractal to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **595 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **596 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -237,6 +237,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - Open-source desktop orchestrator for autonomous coding-agent teams with task delegation, inter-agent messaging, a Kanban board, and code review across multiple agent runtimes.
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - Local-first Agent Operation Environment (AOE) for building or borrowing specialist agents, composing teams, and running them across Claude Code, Codex, Gemini CLI, Cursor, and local models with permission and verification gates.
 - [Better Agent](https://github.com/ofekron/better-agent) - Local workspace for Claude, Codex, and Gemini coding-agent sessions with parallel forks, delegation, persistent state, and restart recovery. Source-available for non-commercial use; commercial use requires permission.
+- [fractal](https://github.com/plasma-ai/fractal) - Hierarchical coding-agent runtime that delegates subtasks recursively and runs each node in its own Git worktree. It provides configurable loop limits, local SQLite state, and live operator controls.
 
 ## Code Generation & Automation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **595個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **596個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -237,6 +237,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Agent Teams AI](https://github.com/777genius/agent-teams-ai) - タスク委譲、エージェント間メッセージング、カンバンボード、コードレビューを備え、複数のエージェント実行環境に対応するオープンソースの自律型コーディングエージェントチーム向けデスクトップオーケストレーター。
 - [Agentlas OS](https://github.com/agentlas-ai/Agentlas-OS) - 専門エージェントの構築・借用、チーム編成、Claude Code・Codex・Gemini CLI・Cursor・ローカルモデルでの実行に対応し、権限と検証ゲートを備えたローカルファーストのAgent Operation Environment (AOE)。
 - [Better Agent](https://github.com/ofekron/better-agent) - Claude、Codex、Geminiのコーディングエージェントセッションを一つのローカルワークスペースで管理し、並列フォーク、タスク委譲、永続状態、再起動後の復旧に対応。非商用利用向けにソース公開され、商用利用には許可が必要。
+- [fractal](https://github.com/plasma-ai/fractal) - 分離可能なサブタスクを子ノードへ再帰的に委譲し、各ノードを専用のGit worktreeで実行する階層型コーディングエージェントランタイム。反復回数・深度・子ノード数・コスト・時間の上限設定、ローカルのSQLiteデータベースによる状態管理、オペレーターによる実行中の指示と停止に対応。
 
 ## コード生成 & 自動化
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Adds [fractal](https://github.com/plasma-ai/fractal) to **Multi-Agent & Orchestration** in both language versions and updates the tool count from 595 to 596.

[fractal](https://github.com/plasma-ai/fractal) を両言語版の **マルチエージェント & オーケストレーション** セクションに追加し、ツール数を595個から596個に更新します。

## Changes / 変更内容

- Added one matching entry to `README.md` and `README_JA.md`
- Updated the total tool count in both files

- `README.md` と `README_JA.md` の同じセクションにエントリを1件ずつ追加
- 両ファイルのツール総数を更新

## Tool Overview / ツールの概要

fractal is a Python runtime for hierarchical coding-agent loops. It delegates separable subtasks to child nodes, gives each node its own Git worktree, stores state and cost data in local SQLite, and applies configurable limits to iterations, depth, children, cost, and time.

fractalは、階層型コーディングエージェントループを実行するPythonランタイムです。分離可能なサブタスクを子ノードへ委譲し、各ノードを専用のGit worktreeで実行します。状態とコストのデータをローカルのSQLiteデータベースに保存し、反復回数・深度・子ノード数・コスト・時間に上限を設定できます。

Disclosure: I am affiliated with Plasma AI, which maintains fractal.

## Checklist / チェックリスト

- [x] The entry is added to both `README.md` and `README_JA.md` / エントリを両方のファイルに追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能
- [x] The tool is related to AI-driven development / AI駆動開発に関連している

## Validation

- Confirmed 596 tool entries in each README
- `git diff --check`
