### PR TITLE
Add DevProjex to Code Analysis & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **597 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **598 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -525,6 +525,7 @@ Tools for analyzing, searching, and understanding codebases.
 - [Project Indexer](https://github.com/Dolfie-01/ProjectIndexer) - A simple script designed to index the locations of classes, files, and other components within a project
 - [codemapper](https://github.com/shaneholloman/codemapper) - A python script that creates a comprehensive Markdown document representing the structure and contents of a given directory
 - [code2prompt](https://github.com/raphaelmansuy/code2prompt) - Code2Prompt is a powerful command-line tool that simplifies the process of providing context to Large Language Models (LLMs) by generating a comprehensive Markdown file containing the content of your codebase
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - Builds clean, AI-ready project context with folder trees, file contents, token counting, Smart Ignore, preview, and multi-format export through a fast GUI and CLI
 - [Code-to-Clipboard-for-LLMs](https://github.com/yigitkonur/code-to-clipboard-for-llms) - Intelligently package your project's code context for LLMs
 - [vibe-log-cli](https://github.com/vibe-log/vibe-log-cli) - Open-source CLI for analyzing Claude Code sessions locally and generating productivity reports
 - [Claude Code Usage Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) - Real-time Claude Code usage monitor with predictions and warnings

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **597個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **598個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -526,6 +526,7 @@ AI支援開発ワークフローを管理するツール、フレームワーク
 - [Project Indexer](https://github.com/Dolfie-01/ProjectIndexer) - プロジェクト内のクラス、ファイル、その他のコンポーネントの場所をインデックス化するシンプルスクリプト
 - [codemapper](https://github.com/shaneholloman/codemapper) - 指定ディレクトリの構造と内容を表現する包括的Markdownドキュメントを作成するpythonスクリプト
 - [code2prompt](https://github.com/raphaelmansuy/code2prompt) - コードベース内容を含む包括的Markdownファイル生成により、大規模言語モデル（LLM）へのコンテキスト提供プロセスを簡素化する強力なコマンドラインツール
+- [DevProjex](https://github.com/Avazbek22/DevProjex) - 高速なGUIとCLIで、フォルダツリー、ファイル内容、トークン数、Smart Ignore、プレビュー、複数形式へのエクスポートを組み合わせ、AI向けに整理されたプロジェクトコンテキストを作成するツール
 - [Code-to-Clipboard-for-LLMs](https://github.com/yigitkonur/code-to-clipboard-for-llms) - LLM向けプロジェクトのコードコンテキストをインテリジェントにパッケージ化
 - [vibe-log-cli](https://github.com/vibe-log/vibe-log-cli) - Claude Codeセッションをローカル解析し生産性レポートを生成するオープンソースCLI
 - [Claude Code Usage Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor) - 予測と警告を備えたリアルタイムClaude Code使用量モニター


### PR DESCRIPTION
## Summary / 変更内容の要約

Added DevProjex to Code Analysis & Search in both language editions.
DevProjexを英語版・日本語版の「コード解析 & 検索」セクションに追加しました。

## Changes / 変更内容

- Added DevProjex to `README.md` and `README_JA.md`
- Updated the total tool count from 597 to 598 in both files

## Tool Overview / ツールの概要

DevProjex builds clean, AI-ready project context from folder trees and file contents through a GUI and CLI, with token counting, Smart Ignore, preview, and multi-format export.

DevProjexは、GUIとCLIを通じてフォルダツリーとファイル内容からAI向けのプロジェクトコンテキストを作成し、トークン数、Smart Ignore、プレビュー、複数形式へのエクスポートに対応します。

## Checklist / チェックリスト

- [x] The entry is added to both `README.md` and `README_JA.md` / エントリを両方に追加した
- [x] All links are valid and reachable / リンクを確認した
- [x] The tool is related to AI-driven development / AI駆動開発に関連している