### PR TITLE
Add API Workbench, Agent Cost Guardrails, MCP Billing Gateway, Feedback Synthesis MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Plugins and extensions for popular IDEs and text editors.
 - [Antigravity Quota Watcher](https://github.com/Henrik-3/AntigravityQuota) - A lightweight VS Code extension that monitors your Antigravity AI model usage quota and displays it in the status bar.
 - [Antigravity Pulse](https://github.com/codavidgarcia/antigravity-pulse) - 100% local & private. Super lightweight. A 120 KB status bar extension for Antigravity Pro & Ultra users who want to monitor their AI model quota at a glance
 - [Pixel Agents](https://github.com/pablodelucca/pixel-agents) - A VS Code extension that turns your AI coding agents into animated pixel art characters in a virtual office.
+- [API Workbench](https://github.com/sapph1re/api-workbench) - VS Code extension for local-first API testing with agent-readable structured markdown output. Git-native collections, multi-environment support, and structured test reports for AI coding assistants.
 
 ### Neovim/Vim
 - [avante.nvim](https://github.com/yetone/avante.nvim) - A Neovim plugin designed to emulate the behaviour of the Cursor AI IDE
@@ -385,6 +386,8 @@ Model Context Protocol servers and integrations for enhanced AI capabilities.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing requests across 30+ image generation models. Zero API key required on first run via Pollinations and Stable Horde free tiers.
 - [Scalekit](https://scalekit.com/) - Auth and tool-calling infrastructure for AI agents with delegated OAuth, secure token vault, and 3000+ connectors.
 - [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) - The fastest and most efficient code intelligence engine for AI coding agents. Full-indexes an average repository in milliseconds, the Linux kernel (28M LOC, 75K files) in 3 minutes.
+- [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) - MCP server that adds usage metering and Stripe billing to any MCP service. Supports per-tool-call pricing, free-tier limits, and subscription plans.
+- [Feedback Synthesis MCP](https://github.com/sapph1re/feedback-synthesis-mcp) - MCP server that synthesizes GitHub Issues, Hacker News threads, and App Store reviews into ranked pain clusters with evidence links.
 
 ## Code Review & Collaboration
 
@@ -703,6 +706,7 @@ Frameworks, libraries, and configurations for building and enhancing AI coding a
 - [rtk - Rust Token Killer](https://github.com/rtk-ai/rtk) - CLI proxy that reduces LLM token consumption by 60-90% on common dev commands. Single Rust binary, zero dependencies
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - A theoretical reconstruction of the Claude Mythos architecture, built from first principles using the available research literature.
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - Production architecture bible for AI-driven development: 54 principles for FastAPI, Next.js 15 & Go 1.22+, with CLAUDE.md, Claude Code skills, and cursor rules.
+- [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - Budget limits and cost guardrails for AI agent frameworks. Framework-native hooks with hard-limit enforcement and circuit breakers for CrewAI, AutoGen, and LangGraph.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Plugins and extensions for popular IDEs and text editors.
 - [Antigravity Quota Watcher](https://github.com/Henrik-3/AntigravityQuota) - A lightweight VS Code extension that monitors your Antigravity AI model usage quota and displays it in the status bar.
 - [Antigravity Pulse](https://github.com/codavidgarcia/antigravity-pulse) - 100% local & private. Super lightweight. A 120 KB status bar extension for Antigravity Pro & Ultra users who want to monitor their AI model quota at a glance
 - [Pixel Agents](https://github.com/pablodelucca/pixel-agents) - A VS Code extension that turns your AI coding agents into animated pixel art characters in a virtual office.
-- [API Workbench](https://github.com/sapph1re/api-workbench) - VS Code extension for local-first API testing with agent-readable structured markdown output. Git-native collections, multi-environment support, and structured test reports for AI coding assistants.
 
 ### Neovim/Vim
 - [avante.nvim](https://github.com/yetone/avante.nvim) - A Neovim plugin designed to emulate the behaviour of the Cursor AI IDE
@@ -386,8 +385,6 @@ Model Context Protocol servers and integrations for enhanced AI capabilities.
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing requests across 30+ image generation models. Zero API key required on first run via Pollinations and Stable Horde free tiers.
 - [Scalekit](https://scalekit.com/) - Auth and tool-calling infrastructure for AI agents with delegated OAuth, secure token vault, and 3000+ connectors.
 - [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) - The fastest and most efficient code intelligence engine for AI coding agents. Full-indexes an average repository in milliseconds, the Linux kernel (28M LOC, 75K files) in 3 minutes.
-- [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) - MCP server that adds usage metering and Stripe billing to any MCP service. Supports per-tool-call pricing, free-tier limits, and subscription plans.
-- [Feedback Synthesis MCP](https://github.com/sapph1re/feedback-synthesis-mcp) - MCP server that synthesizes GitHub Issues, Hacker News threads, and App Store reviews into ranked pain clusters with evidence links.
 
 ## Code Review & Collaboration
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -139,7 +139,6 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Antigravity Quota Watcher](https://github.com/Henrik-3/AntigravityQuota) - Antigravity AIモデルの使用量クォータを監視してステータスバーに表示する軽量VS Code拡張機能
 - [Antigravity Pulse](https://github.com/codavidgarcia/antigravity-pulse) - 100%ローカル＆プライベート。超軽量。Antigravity Pro & Ultraユーザー向けのAIモデルクォータを一目で監視できる120KBのステータスバー拡張機能
 - [Pixel Agents](https://github.com/pablodelucca/pixel-agents) - AIコーディングエージェントをバーチャルオフィス内のアニメーションピクセルアートキャラクターとして表示するVS Code拡張機能
-- [API Workbench](https://github.com/sapph1re/api-workbench) - AIコーディングアシスタント向けのエージェント対応構造化マークダウン出力を提供するローカルファーストなAPIテスト用VS Code拡張機能。Gitネイティブのコレクション、マルチ環境対応。
 
 ### Neovim/Vim
 - [avante.nvim](https://github.com/yetone/avante.nvim) - Cursor AI IDEの動作を模倣するNeovimプラグイン
@@ -385,8 +384,6 @@ AI機能強化のためのModel Context Protocolサーバーと統合。
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - 30以上の画像生成モデル間でリクエストをルーティングし、本番環境向けビジュアルアセット（アプリアイコン、ファビコン、OG画像、ロゴ、ワードマーク）を生成するMCPサーバー。PollinationsとStable Hordeの無料枠を利用して初回実行時にAPIキーが不要
 - [Scalekit](https://scalekit.com/) - 委任OAuth、セキュアトークンボールト、3000以上のコネクタを備えたAIエージェント向けの認証・ツール呼び出しインフラ
 - [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) - AIコーディングエージェント向けの最速かつ最も効率的なコードインテリジェンスエンジン。平均的なリポジトリをミリ秒で、Linuxカーネル（2800万行、7万5千ファイル）を3分で完全インデックス化する。
-- [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) - 任意のMCPサービスに使用量計測とStripe課金を追加するMCPサーバー。ツール呼び出しごとの料金設定、無料枠制限、サブスクリプションプランに対応。
-- [Feedback Synthesis MCP](https://github.com/sapph1re/feedback-synthesis-mcp) - GitHubのIssue、HackerNewsのスレッド、App Storeのレビューを根拠リンク付きのランク付けされた課題クラスターに集約するMCPサーバー。
 
 ## コードレビュー & コラボレーション
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -139,6 +139,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Antigravity Quota Watcher](https://github.com/Henrik-3/AntigravityQuota) - Antigravity AIモデルの使用量クォータを監視してステータスバーに表示する軽量VS Code拡張機能
 - [Antigravity Pulse](https://github.com/codavidgarcia/antigravity-pulse) - 100%ローカル＆プライベート。超軽量。Antigravity Pro & Ultraユーザー向けのAIモデルクォータを一目で監視できる120KBのステータスバー拡張機能
 - [Pixel Agents](https://github.com/pablodelucca/pixel-agents) - AIコーディングエージェントをバーチャルオフィス内のアニメーションピクセルアートキャラクターとして表示するVS Code拡張機能
+- [API Workbench](https://github.com/sapph1re/api-workbench) - AIコーディングアシスタント向けのエージェント対応構造化マークダウン出力を提供するローカルファーストなAPIテスト用VS Code拡張機能。Gitネイティブのコレクション、マルチ環境対応。
 
 ### Neovim/Vim
 - [avante.nvim](https://github.com/yetone/avante.nvim) - Cursor AI IDEの動作を模倣するNeovimプラグイン
@@ -384,6 +385,8 @@ AI機能強化のためのModel Context Protocolサーバーと統合。
 - [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - 30以上の画像生成モデル間でリクエストをルーティングし、本番環境向けビジュアルアセット（アプリアイコン、ファビコン、OG画像、ロゴ、ワードマーク）を生成するMCPサーバー。PollinationsとStable Hordeの無料枠を利用して初回実行時にAPIキーが不要
 - [Scalekit](https://scalekit.com/) - 委任OAuth、セキュアトークンボールト、3000以上のコネクタを備えたAIエージェント向けの認証・ツール呼び出しインフラ
 - [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) - AIコーディングエージェント向けの最速かつ最も効率的なコードインテリジェンスエンジン。平均的なリポジトリをミリ秒で、Linuxカーネル（2800万行、7万5千ファイル）を3分で完全インデックス化する。
+- [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) - 任意のMCPサービスに使用量計測とStripe課金を追加するMCPサーバー。ツール呼び出しごとの料金設定、無料枠制限、サブスクリプションプランに対応。
+- [Feedback Synthesis MCP](https://github.com/sapph1re/feedback-synthesis-mcp) - GitHubのIssue、HackerNewsのスレッド、App Storeのレビューを根拠リンク付きのランク付けされた課題クラスターに集約するMCPサーバー。
 
 ## コードレビュー & コラボレーション
 
@@ -702,6 +705,7 @@ AIコーディングアシスタントを構築・強化するためのフレー
 - [rtk - Rust Token Killer](https://github.com/rtk-ai/rtk) - 一般的な開発コマンドでのLLMトークン消費を60〜90%削減するCLIプロキシ。単一のRustバイナリで依存関係ゼロ
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - Claude Mythosアーキテクチャの理論的再構築。利用可能な研究文献を基に第一原理から構築
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - AI駆動開発のための本番アーキテクチャバイブル。FastAPI、Next.js 15、Go 1.22+向けの54の原則をCLAUDE.md、Claude Codeスキル、cursorルールとともに提供
+- [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - AIエージェントフレームワーク向けの予算制限・コストガードレール。CrewAI、AutoGen、LangGraphに対応したフレームワークネイティブフックとサーキットブレーカーを提供。
 
 ## スキル
 


### PR DESCRIPTION
Adds four tools to the list:

**IDE Extensions > VS Code**
- [API Workbench](https://github.com/sapph1re/api-workbench) — VS Code extension for local-first API testing with agent-readable structured markdown output. Git-native collections, multi-environment support.

**MCP Servers & Integrations**
- [MCP Billing Gateway](https://github.com/sapph1re/mcp-billing-gateway-sdk) — MCP server that adds usage metering and Stripe billing to any MCP service. Supports per-tool-call pricing, free-tier limits, and subscription plans.
- [Feedback Synthesis MCP](https://github.com/sapph1re/feedback-synthesis-mcp) — MCP server that synthesizes GitHub Issues, Hacker News threads, and App Store reviews into ranked pain clusters with evidence links.

**Frameworks & Libraries**
- [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) — Budget limits and cost guardrails for AI agent frameworks. Framework-native hooks with hard-limit enforcement and circuit breakers for CrewAI, AutoGen, and LangGraph.

All four repos are public on GitHub (MIT license). README_JA.md updated with Japanese translations in the matching sections.

Checklist:
- [x] No duplicate entries
- [x] Links are valid
- [x] Descriptions are factual and concise
- [x] README_JA.md updated in matching sections