### PR TITLE
Add THROUGHLINE to Development Workflows & Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **601 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **602 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -519,6 +519,7 @@ Tools, frameworks, and autonomous agents for managing AI-assisted development wo
 - [Holy Grail AI System](https://github.com/dakotalock/holygrailopensource) - Fully autonomous AI development agent with stateful memory, live web access, pseudo self-improvement and more!
 - [AGR: Artificial General Research](https://github.com/JoaquinMulet/Artificial-General-Research) - Autonomous code optimization that works while you sleep (Autoresearch with Claude Code). Define a metric, point it at your code, go to bed. Wake up to a faster, smaller, better system — with correctness verified at every step.
 - [Claude Code SDLC Wizard](https://github.com/BaseInfinity/claude-sdlc-wizard) - A self-evolving Software Development Life Cycle (SDLC) enforcement system for AI coding agents. Makes Claude plan before coding, test before shipping, and ask when uncertain. Measures itself getting better over time.
+- [THROUGHLINE](https://github.com/hellomyoh/throughline) - Spec-driven development framework for AI coding agents, built from markdown and git with no runtime or CLI. Personas review each spec before code, and an append-only single source of truth keeps decisions consistent across sessions. Works with Claude Code, Codex, and Cursor.
 
 ## Code Analysis & Search
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **601個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **602個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -518,6 +518,7 @@ AI支援開発ワークフローを管理するツール、フレームワーク
 - [Holy Grail AI System](https://github.com/dakotalock/holygrailopensource) - ステートフルメモリ、ライブWebアクセス、疑似自己改善などを備えた完全自律AI開発エージェント
 - [AGR: Artificial General Research](https://github.com/JoaquinMulet/Artificial-General-Research) - 寝ている間に動く自律コード最適化（Claude Codeによるオートリサーチ）。メトリクスを定義し、コードを指定して就寝。正確性を毎ステップ検証しながら、より速く、より小さく、より良いシステムに目覚める
 - [Claude Code SDLC Wizard](https://github.com/BaseInfinity/claude-sdlc-wizard) - AIコーディングエージェント向けの自己進化型ソフトウェア開発ライフサイクル（SDLC）強制システム。Claudeにコーディング前のプランニング、出荷前のテスト、不確かなときの質問を促す。時間とともに自身が改善していく様子を測定する。
+- [THROUGHLINE](https://github.com/hellomyoh/throughline) - AIコーディングエージェント向けの仕様駆動開発フレームワーク。Markdownとgitのみで構成され、ランタイムもCLIも不要。コードを書く前にペルソナが各仕様をレビューし、追記専用の単一情報源（SSOT）がセッションをまたいで決定内容の一貫性を保つ。Claude Code、Codex、Cursorに対応。
 
 ## コード解析 & 検索
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added [THROUGHLINE](https://github.com/hellomyoh/throughline) to the Development Workflows & Agents section.
Development Workflows & Agents セクションに [THROUGHLINE](https://github.com/hellomyoh/throughline) を追加しました。

## Changes / 変更内容

```text
- Added THROUGHLINE (https://github.com/hellomyoh/throughline) to the Development Workflows & Agents section
  THROUGHLINE (https://github.com/hellomyoh/throughline) を Development Workflows & Agents セクションに追加
- Added the same entry to README_JA.md in the same section
  README_JA.md の同じセクションにも同じエントリを追加
- Updated the total tool count from 601 to 602 in both README.md and README_JA.md
  README.md と README_JA.md の両方でツール総数を601個から602個に更新
```

## Tool Overview / ツールの概要

```text
About THROUGHLINE:
A spec-driven development framework for AI coding agents, built entirely from markdown
and git with no runtime, CLI, or dependencies. Personas review each spec from fixed
viewpoints before code is written, and an append-only single source of truth keeps
earlier decisions retrievable in later sessions instead of being silently overwritten.
The repository ships runnable benchmark pilots for both claims. Works with Claude Code,
Codex, and Cursor. Documentation in English and Korean. MIT licensed.

THROUGHLINEについて：
AIコーディングエージェント向けの仕様駆動開発フレームワーク。Markdownとgitのみで構成され、
ランタイム・CLI・依存関係は不要。コードを書く前にペルソナが固定された観点から各仕様を
レビューし、追記専用の単一情報源（SSOT）により、以前の決定が暗黙に上書きされることなく
後のセッションからも参照できる。両方の主張について実行可能なベンチマークを同梱。
Claude Code、Codex、Cursorに対応。ドキュメントは英語と韓国語。MITライセンス。
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している

🤖 Generated with [Claude Code](https://claude.com/claude-code)