### PR TITLE
Add AIWorkHub to multi-agent orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **604 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **605 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -218,6 +218,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Agent Deck](https://github.com/asheshgoplani/agent-deck) - Terminal session manager for AI coding agents. Built with Go + Bubble Tea.
 - [PAF Framework](https://github.com/crack00r/paf-framework) - A comprehensive multi-agent orchestration framework that implements a complete Software Development Life Cycle (SDLC) with 38 specialized AI agents. Using hierarchical team structures and the nested-subagent plugin, PAF enables enterprise-grade code reviews, feature development, and project management.
 - [1Code](https://github.com/21st-dev/1code) - Better UI app for running code agents in parallel (ClaudeCode, OpenCode, Codex)
+- [AIWorkHub](https://github.com/shrec/AIWorkHub) - Open-source, repository-native control plane for multi-model coding agents with dependency-aware task DAGs, isolated workers, durable context, source intelligence, and evidence-based review.
 - [aistack](https://github.com/blackms/aistack) - Production-grade agent orchestration with adversarial validation, persistent memory, and real-time web dashboard
 - [OpenCode Orchestrator](https://github.com/agnusdei1207/opencode-orchestrator) - Production-Grade Multi-Agent Orchestration Engine for High-Integrity Software Engineering
 - [Cline ACP](https://github.com/Tonksthebear/cline-acp) - An ACP-compatible coding agent powered by Cline.

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **604個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **605個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -218,6 +218,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Agent Deck](https://github.com/asheshgoplani/agent-deck) - AIコーディングエージェント向けターミナルセッションマネージャー。GoとBubble Teaで構築
 - [PAF Framework](https://github.com/crack00r/paf-framework) - 38の専門AIエージェントを使用した完全なソフトウェア開発ライフサイクル（SDLC）を実装する包括的マルチエージェントオーケストレーションフレームワーク。階層的なチーム構造とnested-subagentプラグインにより、エンタープライズグレードのコードレビュー、機能開発、プロジェクト管理を実現
 - [1Code](https://github.com/21st-dev/1code) - コードエージェント（ClaudeCode、OpenCode、Codex）を並列実行するためのより良いUIアプリ
+- [AIWorkHub](https://github.com/shrec/AIWorkHub) - 依存関係付きタスクDAG、分離ワーカー、永続コンテキスト、ソースインテリジェンス、エビデンスベースのレビューを備えた、オープンソースでリポジトリネイティブなマルチモデルAIコーディングエージェント制御基盤。
 - [aistack](https://github.com/blackms/aistack) - 敵対的検証、永続メモリ、リアルタイムWebダッシュボードを備えた本番環境対応エージェントオーケストレーション
 - [OpenCode Orchestrator](https://github.com/agnusdei1207/opencode-orchestrator) - 高品質ソフトウェアエンジニアリングのための本番環境対応マルチエージェントオーケストレーションエンジン
 - [Cline ACP](https://github.com/Tonksthebear/cline-acp) - Clineを利用したACP（Agent Client Protocol）互換コーディングエージェント


### PR DESCRIPTION
## Summary / 変更内容の要約

Added AIWorkHub to the Multi-Agent & Orchestration section in English and Japanese.

AIWorkHubを英語版・日本語版の「マルチエージェント & オーケストレーション」セクションに追加しました。

## Changes / 変更内容

- Added AIWorkHub to `README.md` and `README_JA.md`.
- Updated the total tool count from 604 to 605 in both files.

- `README.md`と`README_JA.md`にAIWorkHubを追加しました。
- 両方のファイルでツール総数を604から605に更新しました。

## Tool Overview / ツールの概要

AIWorkHub is an open-source, repository-native control plane for multi-model AI
coding agents. It provides dependency-aware task DAGs, isolated workers,
durable context, structural source intelligence and evidence-based review.

AIWorkHubは、マルチモデルAIコーディングエージェント向けのオープンソースで
リポジトリネイティブな制御基盤です。依存関係付きタスクDAG、分離ワーカー、
永続コンテキスト、構造的なソースインテリジェンス、エビデンスベースのレビューを提供します。

## Checklist / チェックリスト

- [x] The entry is added to both README files / 両方のREADMEに追加
- [x] All links are valid and reachable / リンクを確認済み
- [x] The tool is related to AI-driven development / AI駆動開発に関連
