### PR TITLE
Update pm-skills entry: 24 skills is stale, the library now ships 68

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ Reusable skill packages, collections, and tools for enhancing AI coding agents w
 - [MyVibe Skills](https://github.com/ArcBlock/myvibe-skills) - Instantly publish AI-generated web apps to MyVibe.so. Auto-detects Static, Vite, Next.js, Astro, and Nuxt projects with smart build integration.
 - [Heavy3 Code Audit (`/h3`)](https://github.com/heavy3-ai/code-audit) - Agent skill that uses multi-model consensus to review plans, code, and PRs for coding agents
 - [setup-structure-index](https://github.com/shannonbay/setup-structure-index) - A Claude Code skill that sets up a two-tier codebase structure index for any project.
-- [pm-skills](https://github.com/product-on-purpose/pm-skills) - 24 plug-and-play product management agent skills with templates and workflow bundles, following the agentskills.io specification.
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - 68 product management agent skills covering discovery through iteration, with 6 sub-agents, 12 workflows, and 200+ sample outputs. CI-validated skill contracts, following the agentskills.io specification.
 - [Mysti](https://github.com/DeepMyst/Mysti) - Multi-agent AI coding assistant for VS Code with brainstorm mode | Claude Code, Codex, Gemini, Cline, GitHub Copilot |
 - [naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming skill for products, SaaS, brands, and open source projects. Structured process that produces memorable, meaningful names.
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI and MCP server that removes AI writing patterns from agent-generated text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with Claude Code, Codex, Gemini CLI, and Cursor.

--- a/README_JA.md
+++ b/README_JA.md
@@ -729,7 +729,7 @@ AIコーディングエージェントに専門的な機能を付与するため
 - [MyVibe Skills](https://github.com/ArcBlock/myvibe-skills) - AI生成Webアプリを即座にMyVibe.soに公開。Static、Vite、Next.js、Astro、Nuxtプロジェクトを自動検出し、スマートビルド統合を実現
 - [Heavy3 Code Audit (`/h3`)](https://github.com/heavy3-ai/code-audit) - コーディングエージェントのプラン、コード、PRをマルチモデルコンセンサスでレビューするエージェントスキル
 - [setup-structure-index](https://github.com/shannonbay/setup-structure-index) - 任意のプロジェクト用に2段階のコードベース構造インデックスをセットアップするClaude Codeスキル
-- [pm-skills](https://github.com/product-on-purpose/pm-skills) - agentskills.io仕様に準拠した、24のプラグアンドプレイ型プロダクトマネジメントエージェントスキル（テンプレートとワークフローバンドル付き）
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - agentskills.io仕様に準拠した、68のプロダクトマネジメントエージェントスキル。ディスカバリーからイテレーションまでを網羅し、6つのサブエージェント、12のワークフロー、200以上のサンプル出力を含む。スキル契約はCIで検証される
 - [Mysti](https://github.com/DeepMyst/Mysti) - VS Code向けマルチエージェントAIコーディングアシスタント（ブレインストームモード搭載）| Claude Code、Codex、Gemini、Cline、GitHub Copilot |
 - [naming](https://github.com/glacierphonk/naming) - プロダクト、SaaS、ブランド、オープンソースプロジェクトのためのメタファー駆動型ネーミングスキル。記憶に残る意味のある名前を生成する構造化プロセス
 - [unslop](https://github.com/MohamedAbdallah-14/unslop) - エージェント生成テキストからAIライティングパターン（三段論法、emダッシュの多用、ヘッジング、ご機嫌取りの書き出し、過剰使用語彙）を除去するCLIおよびMCPサーバー。Claude Code、Codex、Gemini CLI、Cursorに対応


### PR DESCRIPTION
## Summary / 変更内容の要約

Updates the existing pm-skills entry, whose description is out of date. It says 24 skills; the library now ships 68. No new entry is added.

既存の pm-skills エントリの説明が古くなっているため更新します。24スキルと記載されていますが、現在は68スキルに増えています。新規エントリの追加はありません。

## Changes / 変更内容

```text
- Updated the pm-skills (https://github.com/product-on-purpose/pm-skills) description
  in the Skills & Agent Packages section: 24 skills -> 68 skills, and added the
  sub-agent / workflow / sample counts
  Skills & Agent Packages セクションの pm-skills の説明を更新（24スキル -> 68スキル、
  サブエージェント数・ワークフロー数・サンプル数を追記）

- Applied the same update to README_JA.md so both files stay in sync
  README_JA.md にも同じ更新を適用し、両ファイルを同期

- Total tool count NOT changed, since this edits an existing entry rather than adding one
  既存エントリの更新のため、ツール総数は変更していません
```

## Tool Overview / ツールの概要

```text
About pm-skills:
A library of product management agent skills for AI coding assistants. It covers the
full product lifecycle, from discovery and problem definition through delivery,
measurement, and iteration. Alongside the 68 skills it ships 6 sub-agents, 12
multi-skill workflows, and 200+ sample outputs. Every skill is held to a contract
validated in CI and versioned with SemVer, so the descriptions and counts stay
accurate as the library changes. Follows the agentskills.io specification and is
Apache 2.0 licensed.

pm-skills について：
AIコーディングアシスタント向けのプロダクトマネジメントエージェントスキルのライブラリ。
ディスカバリーと課題定義から、デリバリー、計測、イテレーションまで、プロダクトライフ
サイクル全体を網羅する。68のスキルに加えて、6つのサブエージェント、12のマルチスキル
ワークフロー、200以上のサンプル出力を同梱。各スキルはCIで検証される契約に従い、SemVer
でバージョン管理されるため、ライブラリの変更に対して説明とカウントの正確性が保たれる。
agentskills.io仕様に準拠し、Apache 2.0ライセンス。
```
