### PR TITLE
Add GraphCode to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [Orkas](https://github.com/Orkas-AI/Orkas) - Open-source local-first desktop workspace for orchestrating Claude Code, Codex CLI, OpenCode, Cline, and built-in agents in parallel with shared files and approval controls.
 - [Garcon](https://github.com/cfal/garcon) - Self-hosted browser and mobile workspace for running and steering parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with integrated terminal, file editing, diff review, Git/PR workflows, mobile approvals, scheduling, and cross-agent transfers.
 - [fractal](https://github.com/plasma-ai/fractal) - Hierarchical coding-agent runtime that delegates subtasks recursively and runs each node in its own Git worktree. It provides configurable loop limits, local SQLite state, and live operator controls.
+- [GraphCode](https://github.com/scgopi/GraphCode) - Native macOS app that wires agent sessions into a graph: each node is a live terminal you can attach to mid-run, each edge a hand-off, message, or spawn that fires unattended. Claude Code, Codex, and Copilot CLI loops on the same graph. Source-available under FSL-1.1-MIT; the CLI and SDK are MIT.
 
 ## Code Generation & Automation
 


### PR DESCRIPTION
Adds [GraphCode](https://github.com/scgopi/GraphCode) to **Multi-Agent & Orchestration**.

A native macOS app that arranges coding-agent sessions as a graph. Each node is a live terminal you can attach to and steer mid-run; each edge is a hand-off, message, or spawn that fires while you're away. Claude Code, Codex, and Copilot CLI loops sit on the same graph, so an edge can hand work from one vendor's agent to another's.

Fits alongside Factory Floor, Orkas and Garcon in that section — the difference is that the edges between sessions are the product, rather than parallel worktrees side by side.

- macOS 15+, Apple Silicon; Developer ID signed and notarized
- Source-available under FSL-1.1-MIT (converts to MIT two years after each release); `GraphcodeKit` and the `graphcode` CLI are MIT. Noted in the entry, matching how Better Agent's licence is called out
- Entry appended to the end of the section, matching the section's existing order

Thanks for maintaining the list.