### PR TITLE
Add Atomic Agent to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **604 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **605 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -113,6 +113,7 @@ AI coding assistants and agents that work directly in your terminal or command l
 - [zerostack](https://github.com/gi-dellav/zerostack) - Unix-inspired lightweight (<20MB RAM usage) AI coding agent written in Rust with worktrees and iterative loops integration
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - Autonomous CLI agent that builds from spec to product with verification gates — work isn't done until it passes a blind-review completion council and evidence checks. Brownfield-ready `loki heal`, local-first (bring your own API keys), 26-tool MCP server, reads AGENTS.md. Source-available (BUSL-1.1)
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAI's coding agent harness and TUI. Fullscreen, mouse interactive, extensible.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. Runs on macOS, Linux, and Windows.
 
 ## IDE Extensions
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **604個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **605個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -113,6 +113,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [zerostack](https://github.com/gi-dellav/zerostack) - Unixに着想を得た軽量（RAM使用量20MB未満）のRust製AIコーディングエージェント。worktreeと反復ループの統合に対応
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - 仕様から製品までを自律的に構築するCLIエージェント。検証ゲートを備え、ブラインドレビュー方式の完了協議会とエビデンスチェックを通過するまで作業を完了とみなさない。ブラウンフィールド対応の`loki heal`、ローカルファースト（自前のAPIキー）、26ツールのMCPサーバー、AGENTS.md読み込み対応。ソースアベイラブル（BUSL-1.1）
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAIのコーディングエージェントハーネス兼TUI。フルスクリーン、マウス操作対応、拡張可能。
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - ローカルファーストのCLI兼TUIコーディングエージェント。llama.cppのフォークを通じてオープンウェイトモデルをすべて自分のマシン上で実行し、アカウントもAPIキーも不要。56個の組み込みツール（ブラウザ、ファイルシステム、git、メモリ、ビジョン）、MCP対応、5層のローカルメモリシステムを備える。macOS、Linux、Windowsに対応。
 
 ## IDE拡張機能
 


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for keeping this list so well organized, it is genuinely one of the most useful maps of the AI-driven development space. Our team would be thrilled if you added us. Happy to adjust the wording or the section if you'd prefer something different.

## Summary / 変更内容の要約

Added [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) to the Terminal & CLI Agents section.
Terminal & CLIエージェントセクションに[Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent)を追加しました。

## Changes / 変更内容

```text
- Added Atomic Agent (https://github.com/AtomicBot-ai/atomic-agent) to the Terminal & CLI Agents section
  Atomic Agent (https://github.com/AtomicBot-ai/atomic-agent) をターミナル & CLIエージェントセクションに追加
- Added the same entry to README_JA.md in the same section
  README_JA.md の同じセクションにも同じエントリを追加
- Updated the total tool count from 604 to 605 in both files
  両ファイルのツール総数を604個から605個に更新
```

## Tool Overview / ツールの概要

```text
About Atomic Agent:
An open-source (MIT) local-first CLI and TUI coding agent. It runs open-weight models
entirely on your machine through a llama.cpp fork, so no account or API key is required
to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory,
vision), supports MCP (Model Context Protocol), and has a five-layer local memory system.
The TUI is built with React and ink. Cross-platform: macOS, Linux, and Windows.
Install with: curl -fsSL https://atomicagent.io/install | sh

Atomic Agentについて：
オープンソース（MIT）のローカルファーストなCLI兼TUIコーディングエージェント。llama.cppの
フォークを通じてオープンウェイトモデルをすべて自分のマシン上で実行するため、インストールと
実行にアカウントもAPIキーも不要。56個の組み込みツール（ブラウザ、ファイルシステム、git、
メモリ、ビジョン）を備え、MCP（Model Context Protocol）に対応し、5層のローカルメモリ
システムを持つ。TUIはReactとinkで構築。macOS、Linux、Windowsに対応。
インストール: curl -fsSL https://atomicagent.io/install | sh
```

Links / リンク:

- Repo: https://github.com/AtomicBot-ai/atomic-agent (MIT, ~2k stars, actively maintained)
- Website: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

One note for transparency: the repo is about 4 months old, but it is active with ~2k stars and is maintained by the AtomicBot-ai organization, which ships several established projects.

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
