### PR TITLE
Add FIM-Midtraining language model

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Specialized language models and AI engines designed for coding and development t
 - [aiXcoder-7B](https://github.com/aixcoder-plugin/aixcoder-7b) - Code Large Language Model
 - [AutoCoder](https://github.com/bin123apple/AutoCoder) - Its test accuracy on the HumanEval base dataset surpasses that of GPT-4 Turbo (April 2024) and GPT-4o
 - [Yi-Coder](https://github.com/01-ai/Yi-Coder) - A series of open-source code language models that delivers state-of-the-art coding performance with fewer than 10 billion parameters
+- [FIM-Midtraining](https://github.com/TIGER-AI-Lab/FIM-Midtraining) - Open code-model mid-training release with function-aware fill-in-the-middle data, six checkpoints, training code, and SWE-Bench evaluation.
 - [Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder) - The code version of Qwen2.5
 - [Lingma-SWE-GPT](https://github.com/LingmaTongyi/Lingma-SWE-GPT) - Inference code of Lingma SWE-GPT
 - [tabby](https://github.com/TabbyML/tabby) - Self-hosted AI coding assistant

--- a/README_JA.md
+++ b/README_JA.md
@@ -467,6 +467,7 @@ AI駆動開発におけるプロジェクト管理、ドキュメント、ナレ
 - [aiXcoder-7B](https://github.com/aixcoder-plugin/aixcoder-7b) - コード大規模言語モデル
 - [AutoCoder](https://github.com/bin123apple/AutoCoder) - HumanEvalベースデータセットでのテスト精度がGPT-4 Turbo（2024年4月）とGPT-4oを上回る
 - [Yi-Coder](https://github.com/01-ai/Yi-Coder) - 100億パラメータ未満で最先端コーディング性能を提供するオープンソースコード言語モデルシリーズ
+- [FIM-Midtraining](https://github.com/TIGER-AI-Lab/FIM-Midtraining) - 関数認識型Fill-in-the-Middleデータ、6つのチェックポイント、学習コード、SWE-Bench評価を公開するコードモデル中間学習プロジェクト
 - [Qwen2.5-Coder](https://github.com/QwenLM/Qwen2.5-Coder) - Qwen2.5のコード版
 - [Lingma-SWE-GPT](https://github.com/LingmaTongyi/Lingma-SWE-GPT) - Lingma SWE-GPTの推論コード
 - [tabby](https://github.com/TabbyML/tabby) - セルフホスト型AIコーディングアシスタント


### PR DESCRIPTION
## Summary

Adds FIM-Midtraining to the existing Language Models & Engines section in both English and Japanese. It is an open code-model mid-training release with six checkpoints, a function-aware FIM corpus, training code, and SWE-Bench evaluation.

## Validation

- Followed the repository requirement to synchronize the English and Japanese READMEs
- Checked the default branch and complete issue/PR history for the project title, arXiv ID, and canonical URL
- `git diff --check` passes

I am submitting this on behalf of repository maintainer Yuxuan Zhang.