### PR TITLE
Add SandBase CLI to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **604 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **605 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -113,6 +113,7 @@ AI coding assistants and agents that work directly in your terminal or command l
 - [zerostack](https://github.com/gi-dellav/zerostack) - Unix-inspired lightweight (<20MB RAM usage) AI coding agent written in Rust with worktrees and iterative loops integration
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - Autonomous CLI agent that builds from spec to product with verification gates — work isn't done until it passes a blind-review completion council and evidence checks. Brownfield-ready `loki heal`, local-first (bring your own API keys), 26-tool MCP server, reads AGENTS.md. Source-available (BUSL-1.1)
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAI's coding agent harness and TUI. Fullscreen, mouse interactive, extensible.
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Open-source MCP CLI that connects Claude Code, Codex, Cursor, Windsurf, and other AI development clients to 2,000+ AI models and APIs without managing separate provider API keys.
 
 ## IDE Extensions
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **604個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **605個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -113,6 +113,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [zerostack](https://github.com/gi-dellav/zerostack) - Unixに着想を得た軽量（RAM使用量20MB未満）のRust製AIコーディングエージェント。worktreeと反復ループの統合に対応
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - 仕様から製品までを自律的に構築するCLIエージェント。検証ゲートを備え、ブラインドレビュー方式の完了協議会とエビデンスチェックを通過するまで作業を完了とみなさない。ブラウンフィールド対応の`loki heal`、ローカルファースト（自前のAPIキー）、26ツールのMCPサーバー、AGENTS.md読み込み対応。ソースアベイラブル（BUSL-1.1）
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAIのコーディングエージェントハーネス兼TUI。フルスクリーン、マウス操作対応、拡張可能。
+- [SandBase CLI](https://github.com/sandbaseai/cli) - Claude Code、Codex、Cursor、WindsurfなどのAI開発クライアントを、個別のプロバイダーAPIキー管理なしで2,000以上のAIモデルとAPIに接続するオープンソースMCP CLI。
 
 ## IDE拡張機能
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added SandBase CLI to the Terminal & CLI Agents section in both English and Japanese, and updated the tool count from 604 to 605.

SandBase CLIを英語版・日本語版の「Terminal & CLI Agents」セクションに追加し、ツール数を604から605に更新しました。

## Changes / 変更内容

- Added the same entry to `README.md` and `README_JA.md`
- Updated both documented totals to 605
- Used the project repository as the canonical link

## Tool Overview / ツールの概要

SandBase CLI is an open-source MCP CLI that connects Claude Code, Codex, Cursor, Windsurf, and other AI development clients to 2,000+ AI models without managing separate provider API keys.

SandBase CLIは、Claude Code、Codex、Cursor、WindsurfなどのAI開発クライアントを、個別のプロバイダーAPIキー管理なしで2,000以上のAIモデルとAPIに接続するオープンソースMCP CLIです。

## Checklist / チェックリスト

- [x] Added to both `README.md` and `README_JA.md`
- [x] Verified the repository link is reachable
- [x] The tool is related to AI-driven development

Disclosure: I am affiliated with SandBase, and this submission was prepared with AI assistance.