### PR TITLE
Add Coworker to eltociear/awesome-AI-driven-development

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A curated list of awesome AI-Driven development tools, frameworks, and resources
 - [🧩 Skills](#skills)
 
 ## AI Code Editors & IDEs
+| **[Coworker](https://github.com/leonjackman/coworker)** | Desktop (Electron) | ✅ (MIT) | Free/BYOK | 20+ providers, MCP | Local-first coding agent with memory, HITL, and 11 languages |
+
 
 Full-featured AI-powered code editors and integrated development environments.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **592 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **593 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -27,8 +27,6 @@ A curated list of awesome AI-Driven development tools, frameworks, and resources
 - [🧩 Skills](#skills)
 
 ## AI Code Editors & IDEs
-| **[Coworker](https://github.com/leonjackman/coworker)** | Desktop (Electron) | ✅ (MIT) | Free/BYOK | 20+ providers, MCP | Local-first coding agent with memory, HITL, and 11 languages |
-
 
 Full-featured AI-powered code editors and integrated development environments.
 
@@ -514,6 +512,7 @@ Tools, frameworks, and autonomous agents for managing AI-assisted development wo
 - [AGR: Artificial General Research](https://github.com/JoaquinMulet/Artificial-General-Research) - Autonomous code optimization that works while you sleep (Autoresearch with Claude Code). Define a metric, point it at your code, go to bed. Wake up to a faster, smaller, better system — with correctness verified at every step.
 - [Claude Code SDLC Wizard](https://github.com/BaseInfinity/claude-sdlc-wizard) - A self-evolving Software Development Life Cycle (SDLC) enforcement system for AI coding agents. Makes Claude plan before coding, test before shipping, and ask when uncertain. Measures itself getting better over time.
 - [THROUGHLINE](https://github.com/hellomyoh/throughline) - Spec-driven development framework for AI coding agents, built from markdown and git with no runtime or CLI. Personas review each spec before code, and an append-only single source of truth keeps decisions consistent across sessions. Works with Claude Code, Codex, and Cursor.
+- [Coworker](https://github.com/leonjackman/coworker) - Local-first desktop coding agent (Electron + React over a Python/LangGraph backend). Plan and Build modes keep write and execute behind a human step; subagents run in parallel or in sequence, each with its own memory and restricted toolset; long-term memory is per-agent/per-project markdown with LLM auto-extract and zip export/import. Ships an embedded Chromium the agent can drive and MCP over stdio/HTTP/SSE/WebSocket/Streamable HTTP, with the UI in 11 languages. Runs against OpenAI, Ollama or any OpenAI-compatible endpoint using your own key. MIT
 
 ## Code Analysis & Search
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **592個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **593個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -513,6 +513,7 @@ AI支援開発ワークフローを管理するツール、フレームワーク
 - [AGR: Artificial General Research](https://github.com/JoaquinMulet/Artificial-General-Research) - 寝ている間に動く自律コード最適化（Claude Codeによるオートリサーチ）。メトリクスを定義し、コードを指定して就寝。正確性を毎ステップ検証しながら、より速く、より小さく、より良いシステムに目覚める
 - [Claude Code SDLC Wizard](https://github.com/BaseInfinity/claude-sdlc-wizard) - AIコーディングエージェント向けの自己進化型ソフトウェア開発ライフサイクル（SDLC）強制システム。Claudeにコーディング前のプランニング、出荷前のテスト、不確かなときの質問を促す。時間とともに自身が改善していく様子を測定する。
 - [THROUGHLINE](https://github.com/hellomyoh/throughline) - AIコーディングエージェント向けの仕様駆動開発フレームワーク。Markdownとgitのみで構成され、ランタイムもCLIも不要。コードを書く前にペルソナが各仕様をレビューし、追記専用の単一情報源（SSOT）がセッションをまたいで決定内容の一貫性を保つ。Claude Code、Codex、Cursorに対応。
+- [Coworker](https://github.com/leonjackman/coworker) - ローカルファーストのデスクトップ型コーディングエージェント（Electron + React、バックエンドはPython/LangGraph）。PlanモードとBuildモードで書き込みと実行の前に人間の確認を挟み、サブエージェントはそれぞれ独自のメモリと制限付きツールセットを持って並列・逐次に動作する。長期メモリはエージェント単位/プロジェクト単位のMarkdownで、LLMによる自動抽出とzip形式のエクスポート/インポートに対応。エージェントが操作できる組み込みChromium、stdio/HTTP/SSE/WebSocket/Streamable HTTP経由のMCPを備え、UIは11言語対応。OpenAI、Ollama、またはOpenAI互換エンドポイントを自分のキーで利用可能。MIT
 
 ## コード解析 & 検索
 


### PR DESCRIPTION
**Coworker** – Local-first AI coding assistant desktop app. MIT licensed. Multi-provider, MCP support. https://github.com/leonjackman/coworker