### PR TITLE
Add OB-1 (open-source terminal coding agent, no API key needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **591 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **592 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -111,6 +111,8 @@ AI coding assistants and agents that work directly in your terminal or command l
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - Autonomous CLI agent that builds from spec to product with verification gates — work isn't done until it passes a blind-review completion council and evidence checks. Brownfield-ready `loki heal`, local-first (bring your own API keys), 26-tool MCP server, reads AGENTS.md. Source-available (BUSL-1.1)
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAI's coding agent harness and TUI. Fullscreen, mouse interactive, extensible.
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system. Runs on macOS, Linux, and Windows.
+- [OB-1](https://github.com/Overbrilliant/ob-1) - Terminal coding agent that runs with no account, no API key and no card: an embedded router inside the CLI process answers the first message through keyless free providers using a signed bundled free-model catalog, with failover to your own keys (OpenRouter, OpenAI, Gemini, Groq) or local runtimes (Ollama, LM Studio, llama.cpp, vLLM, any OpenAI-compatible endpoint). Persistent SQLite project memory with an inspectable fact/relationship graph, repo map, MCP, and OS sandboxing (Seatbelt/bubblewrap). The keyless tier is a bootstrap path with variable model quality and shared limits. Apache-2.0, npm `@overbrilliant/ob1`.
+
 
 ## IDE Extensions
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **591個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **592個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -111,6 +111,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [Loki Mode](https://github.com/asklokesh/loki-mode) - 仕様から製品までを自律的に構築するCLIエージェント。検証ゲートを備え、ブラインドレビュー方式の完了協議会とエビデンスチェックを通過するまで作業を完了とみなさない。ブラウンフィールド対応の`loki heal`、ローカルファースト（自前のAPIキー）、26ツールのMCPサーバー、AGENTS.md読み込み対応。ソースアベイラブル（BUSL-1.1）
 - [Grok Build (`grok`)](https://github.com/xai-org/grok-build) - SpaceXAIのコーディングエージェントハーネス兼TUI。フルスクリーン、マウス操作対応、拡張可能。
 - [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - ローカルファーストのCLI兼TUIコーディングエージェント。llama.cppのフォークを通じてオープンウェイトモデルをすべて自分のマシン上で実行し、アカウントもAPIキーも不要。56個の組み込みツール（ブラウザ、ファイルシステム、git、メモリ、ビジョン）、MCP対応、5層のローカルメモリシステムを備える。macOS、Linux、Windowsに対応。
+- [OB-1](https://github.com/Overbrilliant/ob-1) - アカウント・APIキー・クレジットカードなしで動作するターミナルコーディングエージェント。CLIプロセス内に組み込まれたルーターが、署名済みの無料モデルカタログを使ってキー不要の無料プロバイダー経由で最初のメッセージに応答し、自分のキー（OpenRouter、OpenAI、Gemini、Groq）やローカルランタイム（Ollama、LM Studio、llama.cpp、vLLM、OpenAI互換エンドポイント）へフェイルオーバーする。SQLiteによる永続的なプロジェクトメモリ（検査可能なファクト/関係グラフ）、リポジトリマップ、MCP、OSサンドボックス（Seatbelt/bubblewrap）に対応。キー不要ティアはモデル品質が一定せず制限も共有されるブートストラップ用の経路。Apache-2.0、npm `@overbrilliant/ob1`。
 
 ## IDE拡張機能
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added [OB-1](https://github.com/Overbrilliant/ob-1) to the Terminal & CLI Agents section.
ターミナル & CLIエージェントセクションに [OB-1](https://github.com/Overbrilliant/ob-1) を追加しました。

## Changes / 変更内容

```text
- Added OB-1 (https://github.com/Overbrilliant/ob-1) to the Terminal & CLI Agents section, in both README.md and README_JA.md
  OB-1 (https://github.com/Overbrilliant/ob-1) を README.md と README_JA.md の両方のターミナル & CLIエージェントセクションに追加
- Updated the total tool count from 591 to 592 (both files)
  ツール総数を591個から592個に更新（両ファイル）
```

## Tool Overview / ツールの概要

```text
About OB-1:
An open-source terminal coding agent (Apache-2.0, npm @overbrilliant/ob1) whose default path
needs no account, no API key and no card. An embedded router inside the CLI process answers the
first message through keyless free providers using a signed bundled free-model catalog, so there
is no server or proxy to stand up; it fails over to your own keys (OpenRouter, OpenAI, Gemini,
Groq) or local runtimes (Ollama, LM Studio, llama.cpp, vLLM, any OpenAI-compatible endpoint).
It also keeps persistent project memory in SQLite as an inspectable fact/relationship graph, and
supports a repo map, MCP, and OS-level sandboxing (Seatbelt on macOS, bubblewrap on Linux).
Stated plainly in the entry: the keyless tier is a bootstrap path with variable model quality and
shared limits, not a frontier-model tier.

OB-1について：
アカウント・APIキー・クレジットカードなしで動作するオープンソースのターミナルコーディングエージェント
（Apache-2.0、npm @overbrilliant/ob1）。CLIプロセス内に組み込まれたルーターが、署名済みの無料モデル
カタログを使ってキー不要の無料プロバイダー経由で最初のメッセージに応答するため、サーバーやプロキシを
別途立てる必要がない。自分のキー（OpenRouter、OpenAI、Gemini、Groq）やローカルランタイム（Ollama、
LM Studio、llama.cpp、vLLM、OpenAI互換エンドポイント）へのフェイルオーバーにも対応。SQLiteによる
永続的なプロジェクトメモリを検査可能なファクト/関係グラフとして保持し、リポジトリマップ、MCP、
OSサンドボックス（macOSのSeatbelt、Linuxのbubblewrap）にも対応する。なお、キー不要ティアはモデル
品質が一定せず制限も共有されるブートストラップ用の経路であり、その旨をエントリにも明記している。
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
