### PR TITLE
Add snip to Frameworks & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ Frameworks, libraries, and configurations for building and enhancing AI coding a
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - A theoretical reconstruction of the Claude Mythos architecture, built from first principles using the available research literature.
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - Production architecture bible for AI-driven development: 54 principles for FastAPI, Next.js 15 & Go 1.22+, with CLAUDE.md, Claude Code skills, and cursor rules.
 - [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - Budget limits and cost guardrails for AI agent frameworks. Framework-native hooks with hard-limit enforcement and circuit breakers for CrewAI, AutoGen, and LangGraph.
-- [snip](https://github.com/edouard-claude/snip) - CLI proxy that filters shell output before it reaches an AI coding agent, cutting token consumption by 60-90% on common dev commands. Single Go binary; its 132 filters are declarative YAML files rather than compiled code, and it installs as a native hook for 13 agents.
+- [snip](https://github.com/edouard-claude/snip) - CLI proxy that filters shell output before it reaches an AI coding agent, cutting token consumption by 60-90% on common dev commands. Single Go binary; its 132 filters are declarative YAML files rather than compiled code, and it integrates with 13 agents, as a native shell hook for Claude Code, Cursor, Copilot, Codex, Pi and Grok, and as injected rules files for the others.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **594 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **595 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -692,6 +692,7 @@ Frameworks, libraries, and configurations for building and enhancing AI coding a
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - A theoretical reconstruction of the Claude Mythos architecture, built from first principles using the available research literature.
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - Production architecture bible for AI-driven development: 54 principles for FastAPI, Next.js 15 & Go 1.22+, with CLAUDE.md, Claude Code skills, and cursor rules.
 - [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - Budget limits and cost guardrails for AI agent frameworks. Framework-native hooks with hard-limit enforcement and circuit breakers for CrewAI, AutoGen, and LangGraph.
+- [snip](https://github.com/edouard-claude/snip) - CLI proxy that filters shell output before it reaches an AI coding agent, cutting token consumption by 60-90% on common dev commands. Single Go binary; its 132 filters are declarative YAML files rather than compiled code, and it installs as a native hook for 13 agents.
 
 ## Skills
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -693,7 +693,7 @@ AIコーディングアシスタントを構築・強化するためのフレー
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - Claude Mythosアーキテクチャの理論的再構築。利用可能な研究文献を基に第一原理から構築
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - AI駆動開発のための本番アーキテクチャバイブル。FastAPI、Next.js 15、Go 1.22+向けの54の原則をCLAUDE.md、Claude Codeスキル、cursorルールとともに提供
 - [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - AIエージェントフレームワーク向けの予算制限・コストガードレール。CrewAI、AutoGen、LangGraphに対応したフレームワークネイティブフックとサーキットブレーカーを提供。
-- [snip](https://github.com/edouard-claude/snip) - シェル出力をAIコーディングエージェントに渡す前にフィルタリングし、一般的な開発コマンドでトークン消費を60〜90%削減するCLIプロキシ。単一のGoバイナリで、132個のフィルターはコンパイル済みコードではなく宣言的なYAMLファイルとして定義され、13種類のエージェントにネイティブフックとして導入可能
+- [snip](https://github.com/edouard-claude/snip) - シェル出力をAIコーディングエージェントに渡す前にフィルタリングし、一般的な開発コマンドでトークン消費を60〜90%削減するCLIプロキシ。単一のGoバイナリで、132個のフィルターはコンパイル済みコードではなく宣言的なYAMLファイルとして定義され、13種類のエージェントに対応し、Claude Code、Cursor、Copilot、Codex、Pi、Grokにはネイティブなシェルフック、その他にはルールファイルの注入として導入される
 
 ## スキル
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **594個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **595個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -693,6 +693,7 @@ AIコーディングアシスタントを構築・強化するためのフレー
 - [OpenMythos](https://github.com/kyegomez/OpenMythos) - Claude Mythosアーキテクチャの理論的再構築。利用可能な研究文献を基に第一原理から構築
 - [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - AI駆動開発のための本番アーキテクチャバイブル。FastAPI、Next.js 15、Go 1.22+向けの54の原則をCLAUDE.md、Claude Codeスキル、cursorルールとともに提供
 - [agent-cost-guardrails](https://github.com/sapph1re/agent-cost-guardrails) - AIエージェントフレームワーク向けの予算制限・コストガードレール。CrewAI、AutoGen、LangGraphに対応したフレームワークネイティブフックとサーキットブレーカーを提供。
+- [snip](https://github.com/edouard-claude/snip) - シェル出力をAIコーディングエージェントに渡す前にフィルタリングし、一般的な開発コマンドでトークン消費を60〜90%削減するCLIプロキシ。単一のGoバイナリで、132個のフィルターはコンパイル済みコードではなく宣言的なYAMLファイルとして定義され、13種類のエージェントにネイティブフックとして導入可能
 
 ## スキル
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added [snip](https://github.com/edouard-claude/snip) to the Frameworks & Libraries section, in both `README.md` and `README_JA.md`.
Frameworks & Librariesセクションに snip を追加しました（`README.md` と `README_JA.md` の両方）。

## Changes / 変更内容

```text
- Added snip (https://github.com/edouard-claude/snip) to the Frameworks & Libraries section
  snip (https://github.com/edouard-claude/snip) を Frameworks & Libraries セクションに追加
- Updated the total tool count from 594 to 595
  ツール総数を594個から595個に更新
```

## Tool Overview / ツールの概要

```text
About snip:

snip is a CLI proxy that filters shell output before it reaches an AI coding
agent's context window, cutting token consumption by 60-90% on common dev
commands (project-measured: go test ./... 275 -> 8 tokens, git log 371 -> 53).

It sits next to rtk, already listed in this section, but takes the opposite
approach to extensibility: the binary is the engine and the filters are data.
All 132 filters are declarative YAML pipelines shipped in the repository, each
with inline tests run in CI, so a filter can be written, audited or overridden
without touching Go.

It installs as a native hook for 13 agents (Claude Code, Cursor, Copilot,
Codex, Gemini CLI, Windsurf, Cline, Kilo Code, Antigravity, Pi, Grok, OpenCode,
OpenClaw). MIT, static Go binary, no runtime dependency.

Disclosure: I am the author.
```