### PR TITLE
Add YYLO to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **594 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **595 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -241,6 +241,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [fractal](https://github.com/plasma-ai/fractal) - Hierarchical coding-agent runtime that delegates subtasks recursively and runs each node in its own Git worktree. It provides configurable loop limits, local SQLite state, and live operator controls.
 - [GraphCode](https://github.com/scgopi/GraphCode) - Native macOS app that wires agent sessions into a graph: each node is a live terminal you can attach to mid-run, each edge a hand-off, message, or spawn that fires unattended. Claude Code, Codex, and Copilot CLI loops on the same graph. Source-available under FSL-1.1-MIT; the CLI and SDK are MIT.
 - [RailWarden](https://github.com/advaith-1212/railwarden) - Deterministic execution and integration control plane for multi-agent development with dependency-aware work packages, isolated Git worktrees, validation evidence, and mechanical integration gates.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes. Each task runs in a dedicated branch/worktree behind typed task, validation, merge, and release-readiness boundaries, and a merge queue owns risk-based review. Delegates agent runs to Pi and Codex subagents. MIT, npm @yylo/cli.
 
 ## Code Generation & Automation
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **594個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **595個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -241,6 +241,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [fractal](https://github.com/plasma-ai/fractal) - 分離可能なサブタスクを子ノードへ再帰的に委譲し、各ノードを専用のGit worktreeで実行する階層型コーディングエージェントランタイム。反復回数・深度・子ノード数・コスト・時間の上限設定、ローカルのSQLiteデータベースによる状態管理、オペレーターによる実行中の指示と停止に対応。
 - [GraphCode](https://github.com/scgopi/GraphCode) - エージェントセッションをグラフとして配線するネイティブmacOSアプリ。各ノードは実行中に接続できるライブターミナル、各エッジは無人で発火するハンドオフ・メッセージ・スポーン。Claude Code、Codex、Copilot CLIのループを同一グラフ上で扱える。FSL-1.1-MITのソースアベイラブルで、CLIとSDKはMIT
 - [RailWarden](https://github.com/advaith-1212/railwarden) - 依存関係を考慮した作業パッケージ、隔離されたGit worktree、検証エビデンス、機械的な統合ゲートを備えた、マルチエージェント開発向けの決定論的な実行・統合制御プレーン。
+- [YYLO](https://github.com/yylo-dev/yylo) - コーディングエージェント、反復可能なワークフロー、レシート付きのリポジトリ変更のためのコマンドラインオーケストレーター。各タスクは型付きのタスク・検証・マージ・リリース準備の境界の内側で専用ブランチ/worktreeとして実行され、マージキューがリスクベースレビューを担う。PiおよびCodexサブエージェントに実行を委譲。MIT、npm @yylo/cli。
 
 ## コード生成 & 自動化
 


### PR DESCRIPTION
## Summary / 変更内容の要約

Added [YYLO](https://github.com/yylo-dev/yylo) to the Multi-Agent & Orchestration section.
[YYLO](https://github.com/yylo-dev/yylo) をマルチエージェント & オーケストレーションセクションに追加しました。

## Changes / 変更内容

```text
- Added YYLO (https://github.com/yylo-dev/yylo) to the Multi-Agent & Orchestration section
  YYLO (https://github.com/yylo-dev/yylo) をマルチエージェント & オーケストレーションセクションに追加
- Updated the total tool count from 594 to 595
  ツール総数を594個から595個に更新
```

## Tool Overview / ツールの概要

```text
About YYLO:
YYLO is a command-line orchestrator for coding agents, repeatable workflows, and
receipt-backed repository changes. Each task starts with typed task, validation,
merge, and release-readiness boundaries, runs in a dedicated branch/worktree, and
is integrated through a merge queue that owns risk-based review. It delegates
agent runs to Pi and Codex subagents. Open source (MIT), installed via npm
(@yylo/cli). 57 stars, active development since January 2026.

YYLOについて：
コーディングエージェント、反復可能なワークフロー、レシート付きのリポジトリ変更のための
コマンドラインオーケストレーター。型付きのタスク・検証・マージ・リリース準備の境界で各タスクを
管理し、専用ブランチ/worktreeで実行、リスクベースレビューを担うマージキューで統合する。
PiおよびCodexサブエージェントに実行を委譲。オープンソース（MIT）、npm（@yylo/cli）で提供。
```

Section choice: YYLO could also fit *Terminal & CLI Agents*, but its head noun is an orchestrator of coding agents rather than a coding agent itself — closest to the in-section archetypes RailWarden, zeroshot, and Stoneforge — so Multi-Agent & Orchestration seemed most specific. Happy to re-file if you disagree.

## Disclosure

I'm a member of the YYLO team (self-submission), and this PR was prepared with AI-agent assistance following the repo's own contribution guide; the bilingual two-file + tool-count format follows merged #110 and #114. Please check that the Japanese entry reads naturally.
