### PR TITLE
Add ReadyAgents to Multi-Agent & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **595 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
+A curated list of awesome AI-Driven development tools, frameworks, and resources. Currently featuring **596 tools** to enhance your AI-powered development workflow. Inspired by [AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/).
 
 ## Contents
 
@@ -208,6 +208,7 @@ Frameworks and tools for orchestrating and managing multiple AI agents in develo
 - [HyperAgent](https://github.com/FSoft-AI4Code/HyperAgent) - a generalist multi-agent system designed to tackle a wide spectrum of software engineering (SE) tasks across various programming languages.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) - A platform for AI-powered software development agents. OpenHands agents can do anything a human developer can: modify code, run commands, browse the web, call APIs, and even copy files to remote servers.
 - [Prodigy](https://github.com/iepathos/prodigy) - a workflow orchestration tool that enables development teams to automate complex tasks using Claude AI through structured YAML workflows.
+- [ReadyAgents](https://github.com/readyagents/readyagents-core) - Apache-2.0 local one-shot YAML/JSON agent workflow CLI with tools, approvals, resume, and optional stdio MCP (BYOK).
 - [orchestr8](https://github.com/seth-schultz/orchestr8) - Enterprise-grade autonomous software orchestration for Claude Code with research-driven development. 79+ specialized agents, 31 automated workflows, 3-6x speedups through parallelism and evidence-based decision making.
 - [SWORDSwarm](https://github.com/SWORDOps/SWORDSwarm) - Production-ready multi-agent AI orchestration system with hardware acceleration and AI-powered development tools.
 - [CodeMachine CLI](https://github.com/moazbuilds/CodeMachine-CLI) - a CLI-native orchestration platform that uses coordinated multi-agent AI workflows to adaptively transform specification files into production-ready code. ⚡️

--- a/README_JA.md
+++ b/README_JA.md
@@ -4,7 +4,7 @@
 
 <a href="https://github.com/sindresorhus/awesome"><img src="https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg" alt="Awesome" height="18"></a>
 
-AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **595個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
+AI駆動開発のためのツール、フレームワーク、リソースの厳選されたリスト。現在 **596個のツール** を掲載し、AIによる開発ワークフローを強化します。[AI駆動開発(AI-Driven Development)](https://www.ai-driven.dev/)からインスピレーションを得ています.
 
 ## 目次
 
@@ -208,6 +208,7 @@ AI駆動開発のためのツール、フレームワーク、リソースの厳
 - [HyperAgent](https://github.com/FSoft-AI4Code/HyperAgent) - 様々なプログラミング言語で幅広いソフトウェアエンジニアリング（SE）タスクに対応する汎用マルチエージェントシステム
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) - AI搭載ソフトウェア開発エージェント向けプラットフォーム。コード修正、コマンド実行、Web閲覧、API呼び出しなど人間の開発者ができることを実行
 - [Prodigy](https://github.com/iepathos/prodigy) - 構造化されたYAMLワークフローを通じてClaude AIを使用した複雑なタスクの自動化を可能にするワークフローオーケストレーションツール
+- [ReadyAgents](https://github.com/readyagents/readyagents-core) - Apache-2.0のローカルワンショットYAML/JSONエージェントワークフローCLI。ツール、承認、再開、オプションのstdio MCPに対応（BYOK）。
 - [orchestr8](https://github.com/seth-schultz/orchestr8) - リサーチ駆動開発を備えたClaude Code向けエンタープライズグレードの自律ソフトウェアオーケストレーション。79以上の専門エージェント、31の自動化ワークフロー、並列処理とエビデンスベースの意思決定による3〜6倍の高速化
 - [SWORDSwarm](https://github.com/SWORDOps/SWORDSwarm) - ハードウェアアクセラレーションとAI駆動開発ツールを備えた、本番環境対応のマルチエージェントAIオーケストレーションシステム
 - [CodeMachine CLI](https://github.com/moazbuilds/CodeMachine-CLI) - 協調マルチエージェントAIワークフローを使用して仕様ファイルを本番環境対応コードに適応的に変換するCLIネイティブオーケストレーションプラットフォーム ⚡️


### PR DESCRIPTION
## Summary / 変更内容の要約

Added ReadyAgents to the Multi-Agent & Orchestration section (EN + JA) and bumped the total tool count from 595 to 596.

Multi-Agent & OrchestrationセクションにReadyAgentsを追加し（英語・日本語）、ツール総数を595から596に更新しました。

## Changes / 変更内容

```text
- Added ReadyAgents (https://github.com/readyagents/readyagents-core) to the Multi-Agent & Orchestration section
  ReadyAgents (https://github.com/readyagents/readyagents-core) を Multi-Agent & Orchestration セクションに追加
- Updated the total tool count from 595 to 596
  ツール総数を595個から596個に更新
```

## Tool Overview / ツールの概要

```text
About ReadyAgents:
Apache-2.0 local one-shot YAML/JSON agent workflow CLI with tools, approvals, resume, and optional stdio MCP (BYOK). Always-on packs are waitlisted and not for sale.

ReadyAgentsについて：
Apache-2.0のローカルワンショットYAML/JSONエージェントワークフローCLI。ツール、承認、再開、オプションのstdio MCPに対応（BYOK）。常時稼働パックはウェイトリストのみで販売していません。
```

## Checklist / チェックリスト

- [x] The entry is added to **both** `README.md` and `README_JA.md` / エントリを `README.md` と `README_JA.md` の**両方**に追加した
- [x] All links are valid and reachable / すべてのリンクが有効でアクセス可能であることを確認した
- [x] The tool is related to AI-driven development / ツールがAI駆動開発に関連している
